### PR TITLE
fix-fe: 서체에 font-weight가 적용되지 않는 문제 수정

### DIFF
--- a/frontend/src/components/dashboard/ApplicantCard/style.ts
+++ b/frontend/src/components/dashboard/ApplicantCard/style.ts
@@ -24,13 +24,13 @@ const CardDetail = styled.div`
 `;
 
 const CardHeader = styled.h3`
-  ${({ theme }) => theme.typography.heading[400]};
+  ${({ theme }) => theme.typography.common.block};
   color: ${({ theme }) => theme.baseColors.grayscale[900]};
   margin-bottom: 0.4rem;
 `;
 
 const CardDate = styled.span`
-  ${({ theme }) => theme.typography.heading[300]};
+  ${({ theme }) => theme.typography.common.small};
   color: ${({ theme }) => theme.baseColors.grayscale[800]};
 `;
 

--- a/frontend/src/styles/globalStyles.ts
+++ b/frontend/src/styles/globalStyles.ts
@@ -1,42 +1,26 @@
 import { css } from '@emotion/react';
 
+const fontWeights = [
+  { weight: 400, name: 'Regular' },
+  { weight: 500, name: 'Medium' },
+  { weight: 600, name: 'SemiBold' },
+  { weight: 700, name: 'Bold' },
+  { weight: 800, name: 'ExtraBold' },
+  { weight: 900, name: 'Black' },
+];
+
 const globalStyles = () => css`
-  @font-face {
-    font-family: 'Pretendard';
-    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-    font-weight: 400;
-    font-style: normal;
-  }
-  @font-face {
-    font-family: 'Pretendard';
-    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-    font-weight: 500;
-    font-style: normal;
-  }
-  @font-face {
-    font-family: 'Pretendard';
-    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-    font-weight: 600;
-    font-style: normal;
-  }
-  @font-face {
-    font-family: 'Pretendard';
-    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-    font-weight: 700;
-    font-style: normal;
-  }
-  @font-face {
-    font-family: 'Pretendard';
-    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-    font-weight: 800;
-    font-style: normal;
-  }
-  @font-face {
-    font-family: 'Pretendard';
-    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
-    font-weight: 900;
-    font-style: normal;
-  }
+  ${fontWeights.map(
+    ({ weight, name }) => css`
+      @font-face {
+        font-family: 'Pretendard';
+        src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-${name}.woff')
+          format('woff');
+        font-weight: ${weight};
+        font-style: normal;
+      }
+    `,
+  )}
 
   /* Reset CSS */
   * {


### PR DESCRIPTION
## 작업 내용
- 기존의 `globalStyles`의 설정에 따르면, 모든 font-weight에 동일한 단일 웹폰트(`Pretendard-Regular`)가 적용되어 있습니다.
- 이로 인해 각기 다른 굵기가 적용되어야 할 영역에 모두 단일한 서체 형상이 출력되고 있습니다.
- 이번 PR은 이를 바로잡고, 디자인 시스템에 명시된 서체가 의도대로 출력되도록 수정합니다.

## 관련 이슈
- closes #264 

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?
