### PR TITLE
refactor-be(Applicant): Facade Service 계층 도입

### DIFF
--- a/backend/src/main/java/com/cruru/answer/dto/AnswerResponse.java
+++ b/backend/src/main/java/com/cruru/answer/dto/AnswerResponse.java
@@ -1,8 +1,8 @@
-package com.cruru.applicant.controller.dto;
+package com.cruru.answer.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record QnaResponse(
+public record AnswerResponse(
         @JsonProperty("orderIndex")
         int sequence,
 

--- a/backend/src/main/java/com/cruru/answer/service/AnswerService.java
+++ b/backend/src/main/java/com/cruru/answer/service/AnswerService.java
@@ -1,0 +1,34 @@
+package com.cruru.answer.service;
+
+import com.cruru.answer.domain.Answer;
+import com.cruru.answer.domain.repository.AnswerRepository;
+import com.cruru.applicant.controller.dto.QnaResponse;
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.question.domain.Question;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AnswerService {
+
+    private final AnswerRepository answerRepository;
+
+    public List<Answer> findAllByApplicant(Applicant applicant) {
+        return answerRepository.findAllByApplicant(applicant);
+    }
+
+    public List<QnaResponse> toQnaResponses(List<Answer> answers) {
+        return answers.stream()
+                .map(this::toQnaResponse)
+                .toList();
+    }
+
+    private QnaResponse toQnaResponse(Answer answer) {
+        Question question = answer.getQuestion();
+        return new QnaResponse(question.getSequence(), question.getContent(), answer.getContent());
+    }
+}

--- a/backend/src/main/java/com/cruru/answer/service/AnswerService.java
+++ b/backend/src/main/java/com/cruru/answer/service/AnswerService.java
@@ -23,11 +23,11 @@ public class AnswerService {
 
     public List<AnswerResponse> toAnswerResponses(List<Answer> answers) {
         return answers.stream()
-                .map(this::toQnaResponse)
+                .map(this::toAnswerResponse)
                 .toList();
     }
 
-    private AnswerResponse toQnaResponse(Answer answer) {
+    private AnswerResponse toAnswerResponse(Answer answer) {
         Question question = answer.getQuestion();
         return new AnswerResponse(question.getSequence(), question.getContent(), answer.getContent());
     }

--- a/backend/src/main/java/com/cruru/answer/service/AnswerService.java
+++ b/backend/src/main/java/com/cruru/answer/service/AnswerService.java
@@ -2,7 +2,7 @@ package com.cruru.answer.service;
 
 import com.cruru.answer.domain.Answer;
 import com.cruru.answer.domain.repository.AnswerRepository;
-import com.cruru.applicant.controller.dto.QnaResponse;
+import com.cruru.answer.dto.AnswerResponse;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.question.domain.Question;
 import java.util.List;
@@ -21,14 +21,14 @@ public class AnswerService {
         return answerRepository.findAllByApplicant(applicant);
     }
 
-    public List<QnaResponse> toQnaResponses(List<Answer> answers) {
+    public List<AnswerResponse> toAnswerResponses(List<Answer> answers) {
         return answers.stream()
                 .map(this::toQnaResponse)
                 .toList();
     }
 
-    private QnaResponse toQnaResponse(Answer answer) {
+    private AnswerResponse toQnaResponse(Answer answer) {
         Question question = answer.getQuestion();
-        return new QnaResponse(question.getSequence(), question.getContent(), answer.getContent());
+        return new AnswerResponse(question.getSequence(), question.getContent(), answer.getContent());
     }
 }

--- a/backend/src/main/java/com/cruru/applicant/controller/ApplicantController.java
+++ b/backend/src/main/java/com/cruru/applicant/controller/ApplicantController.java
@@ -1,7 +1,7 @@
 package com.cruru.applicant.controller;
 
+import com.cruru.applicant.controller.dto.ApplicantAnswerResponses;
 import com.cruru.applicant.controller.dto.ApplicantBasicResponse;
-import com.cruru.applicant.controller.dto.ApplicantDetailResponse;
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
 import com.cruru.applicant.service.facade.ApplicantFacade;
@@ -23,15 +23,6 @@ public class ApplicantController {
 
     private final ApplicantFacade applicantFacade;
 
-    @PutMapping("/move-process/{processId}")
-    public ResponseEntity<Void> updateApplicantProcess(
-            @PathVariable Long processId,
-            @RequestBody @Valid ApplicantMoveRequest moveRequest
-    ) {
-        applicantFacade.updateApplicantProcess(processId, moveRequest);
-        return ResponseEntity.ok().build();
-    }
-
     @GetMapping("/{applicantId}")
     public ResponseEntity<ApplicantBasicResponse> read(@PathVariable("applicantId") Long applicantId) {
         ApplicantBasicResponse applicantResponse = applicantFacade.readBasicById(applicantId);
@@ -39,23 +30,32 @@ public class ApplicantController {
     }
 
     @GetMapping("/{applicantId}/detail")
-    public ResponseEntity<ApplicantDetailResponse> readDetail(@PathVariable("applicantId") Long applicantId) {
-        ApplicantDetailResponse applicantDetailResponse = applicantFacade.readDetailById(applicantId);
-        return ResponseEntity.ok().body(applicantDetailResponse);
-    }
-
-    @PatchMapping("/{applicantId}/reject")
-    public ResponseEntity<ApplicantDetailResponse> reject(@PathVariable("applicantId") Long applicantId) {
-        applicantFacade.updateApplicantToReject(applicantId);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<ApplicantAnswerResponses> readDetail(@PathVariable("applicantId") Long applicantId) {
+        ApplicantAnswerResponses applicantAnswerResponses = applicantFacade.readDetailById(applicantId);
+        return ResponseEntity.ok().body(applicantAnswerResponses);
     }
 
     @PatchMapping("/{applicantId}")
-    public ResponseEntity<Void> update(
+    public ResponseEntity<Void> updateInformation(
             @PathVariable("applicantId") Long applicantId,
             @RequestBody @Valid ApplicantUpdateRequest request
     ) {
-        applicantFacade.updateApplicantInformation(request, applicantId);
+        applicantFacade.updateApplicantInformation(applicantId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/move-process/{processId}")
+    public ResponseEntity<Void> updateProcess(
+            @PathVariable Long processId,
+            @RequestBody @Valid ApplicantMoveRequest moveRequest
+    ) {
+        applicantFacade.updateApplicantProcess(processId, moveRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{applicantId}/reject")
+    public ResponseEntity<ApplicantAnswerResponses> updateReject(@PathVariable("applicantId") Long applicantId) {
+        applicantFacade.updateApplicantToReject(applicantId);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/cruru/applicant/controller/ApplicantController.java
+++ b/backend/src/main/java/com/cruru/applicant/controller/ApplicantController.java
@@ -30,25 +30,25 @@ public class ApplicantController {
             @PathVariable Long processId,
             @RequestBody @Valid ApplicantMoveRequest moveRequest
     ) {
-        applicantService.updateApplicantProcess(processId, moveRequest);
+        applicantFacade.updateApplicantProcess(processId, moveRequest);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/{applicantId}")
     public ResponseEntity<ApplicantBasicResponse> read(@PathVariable("applicantId") Long applicantId) {
-        ApplicantBasicResponse applicantResponse = applicantFacade.findById(applicantId);
+        ApplicantBasicResponse applicantResponse = applicantFacade.readBasicById(applicantId);
         return ResponseEntity.ok().body(applicantResponse);
     }
 
     @GetMapping("/{applicantId}/detail")
     public ResponseEntity<ApplicantDetailResponse> readDetail(@PathVariable("applicantId") Long applicantId) {
-        ApplicantDetailResponse applicantDetailResponse = applicantService.findDetailById(applicantId);
+        ApplicantDetailResponse applicantDetailResponse = applicantFacade.readDetailById(applicantId);
         return ResponseEntity.ok().body(applicantDetailResponse);
     }
 
     @PatchMapping("/{applicantId}/reject")
     public ResponseEntity<ApplicantDetailResponse> reject(@PathVariable("applicantId") Long applicantId) {
-        applicantService.reject(applicantId);
+        applicantFacade.updateApplicantToReject(applicantId);
         return ResponseEntity.ok().build();
     }
 
@@ -57,7 +57,7 @@ public class ApplicantController {
             @PathVariable("applicantId") Long applicantId,
             @RequestBody @Valid ApplicantUpdateRequest request
     ) {
-        applicantService.update(request, applicantId);
+        applicantFacade.updateApplicantInformation(request, applicantId);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/cruru/applicant/controller/ApplicantController.java
+++ b/backend/src/main/java/com/cruru/applicant/controller/ApplicantController.java
@@ -4,7 +4,6 @@ import com.cruru.applicant.controller.dto.ApplicantBasicResponse;
 import com.cruru.applicant.controller.dto.ApplicantDetailResponse;
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
-import com.cruru.applicant.service.ApplicantService;
 import com.cruru.applicant.service.facade.ApplicantFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +21,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ApplicantController {
 
-    private final ApplicantService applicantService;
     private final ApplicantFacade applicantFacade;
 
     @PutMapping("/move-process/{processId}")

--- a/backend/src/main/java/com/cruru/applicant/controller/dto/ApplicantAnswerResponses.java
+++ b/backend/src/main/java/com/cruru/applicant/controller/dto/ApplicantAnswerResponses.java
@@ -1,11 +1,12 @@
 package com.cruru.applicant.controller.dto;
 
+import com.cruru.answer.dto.AnswerResponse;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-public record ApplicantDetailResponse(
+public record ApplicantAnswerResponses(
         @JsonProperty("details")
-        List<QnaResponse> qnaResponses
+        List<AnswerResponse> answerResponses
 ) {
 
 }

--- a/backend/src/main/java/com/cruru/applicant/domain/Applicant.java
+++ b/backend/src/main/java/com/cruru/applicant/domain/Applicant.java
@@ -65,16 +65,16 @@ public class Applicant extends BaseEntity {
         this.process = process;
     }
 
-    public void reject() {
-        this.state = REJECTED;
+    public void approve() {
+        this.state = APPROVED;
     }
 
     public void pending() {
         this.state = PENDING;
     }
 
-    public void approve() {
-        this.state = APPROVED;
+    public void reject() {
+        this.state = REJECTED;
     }
 
     public boolean isApproved() {

--- a/backend/src/main/java/com/cruru/applicant/domain/Applicant.java
+++ b/backend/src/main/java/com/cruru/applicant/domain/Applicant.java
@@ -69,6 +69,14 @@ public class Applicant extends BaseEntity {
         this.state = REJECTED;
     }
 
+    public void pending() {
+        this.state = PENDING;
+    }
+
+    public void approve() {
+        this.state = APPROVED;
+    }
+
     public boolean isApproved() {
         return this.state == APPROVED;
     }

--- a/backend/src/main/java/com/cruru/applicant/exception/badrequest/ApplicantNoChangeException.java
+++ b/backend/src/main/java/com/cruru/applicant/exception/badrequest/ApplicantNoChangeException.java
@@ -1,0 +1,12 @@
+package com.cruru.applicant.exception.badrequest;
+
+import com.cruru.advice.badrequest.BadRequestException;
+
+public class ApplicantNoChangeException extends BadRequestException {
+
+    private static final String MESSAGE = "변경된 내용이 없습니다.";
+
+    public ApplicantNoChangeException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
+++ b/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
@@ -40,7 +40,8 @@ public class ApplicantService {
     }
 
     private boolean notChangedInformation(ApplicantUpdateRequest request, Applicant applicant) {
-        return applicant.getName().equals(request.name()) && applicant.getEmail().equals(request.email())
+        return applicant.getName().equals(request.name())
+                && applicant.getEmail().equals(request.email())
                 && applicant.getPhone().equals(request.phone());
     }
 

--- a/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
+++ b/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
@@ -1,19 +1,13 @@
 package com.cruru.applicant.service;
 
-import com.cruru.answer.domain.Answer;
-import com.cruru.answer.domain.repository.AnswerRepository;
-import com.cruru.applicant.controller.dto.ApplicantDetailResponse;
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
-import com.cruru.applicant.controller.dto.QnaResponse;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.applicant.exception.ApplicantNotFoundException;
+import com.cruru.applicant.exception.badrequest.ApplicantNoChangeException;
 import com.cruru.applicant.exception.badrequest.ApplicantRejectException;
 import com.cruru.process.domain.Process;
-import com.cruru.process.domain.repository.ProcessRepository;
-import com.cruru.process.exception.ProcessNotFoundException;
-import com.cruru.question.domain.Question;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,17 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class ApplicantService {
 
     private final ApplicantRepository applicantRepository;
-    private final ProcessRepository processRepository;
-    private final AnswerRepository answerRepository;
-
-    @Transactional
-    public void updateApplicantProcess(long processId, ApplicantMoveRequest moveRequest) {
-        Process process = processRepository.findById(processId)
-                .orElseThrow(ProcessNotFoundException::new);
-
-        List<Applicant> applicants = applicantRepository.findAllById(moveRequest.applicantIds());
-        applicants.forEach(applicant -> applicant.updateProcess(process));
-    }
 
     public List<Applicant> findAllByProcess(Process process) {
         return applicantRepository.findAllByProcess(process);
@@ -46,29 +29,25 @@ public class ApplicantService {
                 .orElseThrow(ApplicantNotFoundException::new);
     }
 
-    public ApplicantDetailResponse findDetailById(long id) {
-        Applicant applicant = applicantRepository.findById(id)
-                .orElseThrow(ApplicantNotFoundException::new);
-        List<Answer> answers = answerRepository.findAllByApplicant(applicant);
-        List<QnaResponse> qnaResponses = toQnaResponses(answers);
-        return new ApplicantDetailResponse(qnaResponses);
-    }
-
-    private List<QnaResponse> toQnaResponses(List<Answer> answers) {
-        return answers.stream()
-                .map(this::toQnaResponse)
-                .toList();
-    }
-
-    private QnaResponse toQnaResponse(Answer answer) {
-        Question question = answer.getQuestion();
-        return new QnaResponse(question.getSequence(), question.getContent(), answer.getContent());
+    @Transactional
+    public void updateApplicantInformation(ApplicantUpdateRequest request, Applicant applicant) {
+        if (applicant.getName().equals(request.name())
+                && applicant.getEmail().equals(request.email())
+                && applicant.getPhone().equals(request.phone())) {
+            throw new ApplicantNoChangeException();
+        }
+        applicant.updateInfo(request.name(), request.email(), request.phone());
     }
 
     @Transactional
-    public void reject(long id) {
-        Applicant applicant = applicantRepository.findById(id)
-                .orElseThrow(ApplicantNotFoundException::new);
+    public void moveApplicantProcess(Process process, ApplicantMoveRequest moveRequest) {
+        List<Applicant> applicants = applicantRepository.findAllById(moveRequest.applicantIds());
+        applicants.forEach(applicant -> applicant.updateProcess(process));
+    }
+
+    @Transactional
+    public void reject(long applicantId) {
+        Applicant applicant = findById(applicantId);
         validateRejectable(applicant);
         applicant.reject();
     }
@@ -77,13 +56,5 @@ public class ApplicantService {
         if (applicant.isRejected()) {
             throw new ApplicantRejectException();
         }
-    }
-
-    @Transactional
-    public void update(ApplicantUpdateRequest request, long applicantId) {
-        Applicant applicant = applicantRepository.findById(applicantId)
-                .orElseThrow(ApplicantNotFoundException::new);
-
-        applicant.updateInfo(request.name(), request.email(), request.phone());
     }
 }

--- a/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
+++ b/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
@@ -1,6 +1,7 @@
 package com.cruru.applicant.service;
 
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
+import com.cruru.applicant.controller.dto.ApplicantResponse;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
@@ -24,19 +25,23 @@ public class ApplicantService {
         return applicantRepository.findAllByProcess(process);
     }
 
+    @Transactional
+    public void updateApplicantInformation(long applicantid, ApplicantUpdateRequest request) {
+        Applicant applicant = findById(applicantid);
+        if (notChangedInformation(request, applicant)) {
+            throw new ApplicantNoChangeException();
+        }
+        applicant.updateInfo(request.name(), request.email(), request.phone());
+    }
+
     public Applicant findById(long applicantId) {
         return applicantRepository.findById(applicantId)
                 .orElseThrow(ApplicantNotFoundException::new);
     }
 
-    @Transactional
-    public void updateApplicantInformation(ApplicantUpdateRequest request, Applicant applicant) {
-        if (applicant.getName().equals(request.name())
-                && applicant.getEmail().equals(request.email())
-                && applicant.getPhone().equals(request.phone())) {
-            throw new ApplicantNoChangeException();
-        }
-        applicant.updateInfo(request.name(), request.email(), request.phone());
+    private boolean notChangedInformation(ApplicantUpdateRequest request, Applicant applicant) {
+        return applicant.getName().equals(request.name()) && applicant.getEmail().equals(request.email())
+                && applicant.getPhone().equals(request.phone());
     }
 
     @Transactional
@@ -56,5 +61,15 @@ public class ApplicantService {
         if (applicant.isRejected()) {
             throw new ApplicantRejectException();
         }
+    }
+
+    public ApplicantResponse toApplicantResponse(Applicant applicant) {
+        return new ApplicantResponse(
+                applicant.getId(),
+                applicant.getName(),
+                applicant.getEmail(),
+                applicant.getPhone(),
+                applicant.getCreatedDate()
+        );
     }
 }

--- a/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
+++ b/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
@@ -26,8 +26,8 @@ public class ApplicantService {
     }
 
     @Transactional
-    public void updateApplicantInformation(long applicantid, ApplicantUpdateRequest request) {
-        Applicant applicant = findById(applicantid);
+    public void updateApplicantInformation(long applicantId, ApplicantUpdateRequest request) {
+        Applicant applicant = findById(applicantId);
         if (notChangedInformation(request, applicant)) {
             throw new ApplicantNoChangeException();
         }

--- a/backend/src/main/java/com/cruru/applicant/service/facade/ApplicantFacade.java
+++ b/backend/src/main/java/com/cruru/applicant/service/facade/ApplicantFacade.java
@@ -1,10 +1,19 @@
 package com.cruru.applicant.service.facade;
 
+import com.cruru.answer.domain.Answer;
+import com.cruru.answer.service.AnswerService;
 import com.cruru.applicant.controller.dto.ApplicantBasicResponse;
+import com.cruru.applicant.controller.dto.ApplicantDetailResponse;
+import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantResponse;
+import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
+import com.cruru.applicant.controller.dto.QnaResponse;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.service.ApplicantService;
 import com.cruru.process.controller.dto.ProcessSimpleResponse;
+import com.cruru.process.domain.Process;
+import com.cruru.process.service.ProcessService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,25 +24,48 @@ import org.springframework.transaction.annotation.Transactional;
 public class ApplicantFacade {
 
     private final ApplicantService applicantService;
+    private final ProcessService processService;
+    private final AnswerService answerService;
 
-    public ApplicantBasicResponse findById(long applicantId) {
+    public ApplicantBasicResponse readBasicById(long applicantId) {
         Applicant applicant = applicantService.findById(applicantId);
         return toApplicantBasicResponse(applicant);
     }
 
     private ApplicantBasicResponse toApplicantBasicResponse(Applicant applicant) {
-        return new ApplicantBasicResponse(
-                new ApplicantResponse(
-                        applicant.getId(),
-                        applicant.getName(),
-                        applicant.getEmail(),
-                        applicant.getPhone(),
-                        applicant.getCreatedDate()
-                ),
-                new ProcessSimpleResponse(
-                        applicant.getProcess().getId(),
-                        applicant.getProcess().getName()
-                )
+        ApplicantResponse applicantResponse = new ApplicantResponse(applicant.getId(),
+                applicant.getName(),
+                applicant.getEmail(),
+                applicant.getPhone(),
+                applicant.getCreatedDate()
         );
+        ProcessSimpleResponse processResponse = new ProcessSimpleResponse(applicant.getProcess().getId(),
+                applicant.getProcess().getName()
+        );
+        return new ApplicantBasicResponse(applicantResponse, processResponse);
+    }
+
+    public ApplicantDetailResponse readDetailById(long id) {
+        Applicant applicant = applicantService.findById(id);
+        List<Answer> answers = answerService.findAllByApplicant(applicant);
+        List<QnaResponse> qnaResponses = answerService.toQnaResponses(answers);
+        return new ApplicantDetailResponse(qnaResponses);
+    }
+
+    @Transactional
+    public void updateApplicantInformation(ApplicantUpdateRequest request, long applicantId) {
+        Applicant applicant = applicantService.findById(applicantId);
+        applicantService.updateApplicantInformation(request, applicant);
+    }
+
+    @Transactional
+    public void updateApplicantProcess(long processId, ApplicantMoveRequest moveRequest) {
+        Process process = processService.findById(processId);
+        applicantService.moveApplicantProcess(process, moveRequest);
+    }
+
+    @Transactional
+    public void updateApplicantToReject(long applicantId) {
+        applicantService.reject(applicantId);
     }
 }

--- a/backend/src/main/java/com/cruru/applicant/service/facade/ApplicantFacade.java
+++ b/backend/src/main/java/com/cruru/applicant/service/facade/ApplicantFacade.java
@@ -1,13 +1,13 @@
 package com.cruru.applicant.service.facade;
 
 import com.cruru.answer.domain.Answer;
+import com.cruru.answer.dto.AnswerResponse;
 import com.cruru.answer.service.AnswerService;
+import com.cruru.applicant.controller.dto.ApplicantAnswerResponses;
 import com.cruru.applicant.controller.dto.ApplicantBasicResponse;
-import com.cruru.applicant.controller.dto.ApplicantDetailResponse;
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantResponse;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
-import com.cruru.applicant.controller.dto.QnaResponse;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.service.ApplicantService;
 import com.cruru.process.controller.dto.ProcessSimpleResponse;
@@ -33,29 +33,21 @@ public class ApplicantFacade {
     }
 
     private ApplicantBasicResponse toApplicantBasicResponse(Applicant applicant) {
-        ApplicantResponse applicantResponse = new ApplicantResponse(applicant.getId(),
-                applicant.getName(),
-                applicant.getEmail(),
-                applicant.getPhone(),
-                applicant.getCreatedDate()
-        );
-        ProcessSimpleResponse processResponse = new ProcessSimpleResponse(applicant.getProcess().getId(),
-                applicant.getProcess().getName()
-        );
+        ApplicantResponse applicantResponse = applicantService.toApplicantResponse(applicant);
+        ProcessSimpleResponse processResponse = processService.toProcessSimpleResponse(applicant.getProcess());
         return new ApplicantBasicResponse(applicantResponse, processResponse);
     }
 
-    public ApplicantDetailResponse readDetailById(long id) {
+    public ApplicantAnswerResponses readDetailById(long id) {
         Applicant applicant = applicantService.findById(id);
         List<Answer> answers = answerService.findAllByApplicant(applicant);
-        List<QnaResponse> qnaResponses = answerService.toQnaResponses(answers);
-        return new ApplicantDetailResponse(qnaResponses);
+        List<AnswerResponse> answerResponses = answerService.toAnswerResponses(answers);
+        return new ApplicantAnswerResponses(answerResponses);
     }
 
     @Transactional
-    public void updateApplicantInformation(ApplicantUpdateRequest request, long applicantId) {
-        Applicant applicant = applicantService.findById(applicantId);
-        applicantService.updateApplicantInformation(request, applicant);
+    public void updateApplicantInformation(long applicantId, ApplicantUpdateRequest request) {
+        applicantService.updateApplicantInformation(applicantId, request);
     }
 
     @Transactional

--- a/backend/src/main/java/com/cruru/process/service/ProcessService.java
+++ b/backend/src/main/java/com/cruru/process/service/ProcessService.java
@@ -9,6 +9,7 @@ import com.cruru.dashboard.exception.DashboardNotFoundException;
 import com.cruru.evaluation.domain.repository.EvaluationRepository;
 import com.cruru.process.controller.dto.ProcessCreateRequest;
 import com.cruru.process.controller.dto.ProcessResponse;
+import com.cruru.process.controller.dto.ProcessSimpleResponse;
 import com.cruru.process.controller.dto.ProcessUpdateRequest;
 import com.cruru.process.controller.dto.ProcessesResponse;
 import com.cruru.process.domain.Process;
@@ -80,6 +81,10 @@ public class ProcessService {
                 applicant.isRejected(),
                 evaluationCount
         );
+    }
+
+    public ProcessSimpleResponse toProcessSimpleResponse(Process process) {
+        return new ProcessSimpleResponse(process.getId(), process.getName());
     }
 
     public List<Process> findAllByDashboardId(long dashboardId) {

--- a/backend/src/test/java/com/cruru/answer/service/AnswerServiceTest.java
+++ b/backend/src/test/java/com/cruru/answer/service/AnswerServiceTest.java
@@ -1,0 +1,84 @@
+package com.cruru.answer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.cruru.answer.domain.Answer;
+import com.cruru.answer.domain.repository.AnswerRepository;
+import com.cruru.answer.dto.AnswerResponse;
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.domain.repository.ApplicantRepository;
+import com.cruru.question.domain.Question;
+import com.cruru.question.domain.repository.QuestionRepository;
+import com.cruru.util.ServiceTest;
+import com.cruru.util.fixture.AnswerFixture;
+import com.cruru.util.fixture.ApplicantFixture;
+import com.cruru.util.fixture.QuestionFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("Answer 서비스 테스트")
+class AnswerServiceTest extends ServiceTest {
+
+    @Autowired
+    private AnswerService answerService;
+
+    @Autowired
+    private AnswerRepository answerRepository;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @DisplayName("지원자의 응답을 조회한다.")
+    @Test
+    void findAllByApplicant() {
+        // given
+        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby());
+        Question question1 = questionRepository.save(QuestionFixture.createShortAnswerQuestion(null));
+        Question question2 = questionRepository.save(QuestionFixture.createShortAnswerQuestion(null));
+
+        List<Answer> expectedAnswers = answerRepository.saveAll(List.of(
+                AnswerFixture.fristAnswer(question1, applicant),
+                AnswerFixture.secondAnswer(question2, applicant)
+        ));
+
+        // when
+        List<Answer> actualAnswers = answerService.findAllByApplicant(applicant);
+
+        // then
+        assertThat(actualAnswers).hasSameElementsAs(expectedAnswers);
+    }
+
+    @Test
+    void toAnswerResponses() {
+        // given
+        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby());
+        Question question1 = questionRepository.save(QuestionFixture.createShortAnswerQuestion(null));
+        Question question2 = questionRepository.save(QuestionFixture.createShortAnswerQuestion(null));
+
+        Answer expectedAnswer1 = AnswerFixture.fristAnswer(question1, applicant);
+        Answer expectedAnswer2 = AnswerFixture.secondAnswer(question2, applicant);
+        List<Answer> expectedAnswers = answerRepository.saveAll(List.of(expectedAnswer1, expectedAnswer2));
+
+        // when
+        List<AnswerResponse> actualAnswerResponses = answerService.toAnswerResponses(expectedAnswers);
+
+        // then
+        AnswerResponse actualAnswerResponse1 = actualAnswerResponses.get(0);
+        AnswerResponse actualAnswerResponse2 = actualAnswerResponses.get(1);
+        assertAll(() -> {
+            assertThat(actualAnswerResponses).hasSize(2);
+
+            assertThat(actualAnswerResponse1.answer()).isEqualTo(expectedAnswer1.getContent());
+            assertThat(actualAnswerResponse2.answer()).isEqualTo(expectedAnswer2.getContent());
+
+            assertThat(actualAnswerResponse1.question()).isEqualTo(question1.getContent());
+            assertThat(actualAnswerResponse2.question()).isEqualTo(question2.getContent());
+        });
+    }
+}

--- a/backend/src/test/java/com/cruru/answer/service/AnswerServiceTest.java
+++ b/backend/src/test/java/com/cruru/answer/service/AnswerServiceTest.java
@@ -58,9 +58,9 @@ class AnswerServiceTest extends ServiceTest {
     @Test
     void toAnswerResponses() {
         // given
-        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby());
-        Question question1 = questionRepository.save(QuestionFixture.createShortAnswerQuestion(null));
-        Question question2 = questionRepository.save(QuestionFixture.createShortAnswerQuestion(null));
+        Applicant applicant = ApplicantFixture.createPendingApplicantDobby();
+        Question question1 = QuestionFixture.createShortAnswerQuestion(null);
+        Question question2 = QuestionFixture.createShortAnswerQuestion(null);
 
         Answer expectedAnswer1 = AnswerFixture.fristAnswer(question1, applicant);
         Answer expectedAnswer2 = AnswerFixture.secondAnswer(question2, applicant);

--- a/backend/src/test/java/com/cruru/answer/service/AnswerServiceTest.java
+++ b/backend/src/test/java/com/cruru/answer/service/AnswerServiceTest.java
@@ -54,6 +54,7 @@ class AnswerServiceTest extends ServiceTest {
         assertThat(actualAnswers).hasSameElementsAs(expectedAnswers);
     }
 
+    @DisplayName("도메인 엔티티를 DTO로 변환한다.")
     @Test
     void toAnswerResponses() {
         // given
@@ -63,7 +64,7 @@ class AnswerServiceTest extends ServiceTest {
 
         Answer expectedAnswer1 = AnswerFixture.fristAnswer(question1, applicant);
         Answer expectedAnswer2 = AnswerFixture.secondAnswer(question2, applicant);
-        List<Answer> expectedAnswers = answerRepository.saveAll(List.of(expectedAnswer1, expectedAnswer2));
+        List<Answer> expectedAnswers = List.of(expectedAnswer1, expectedAnswer2);
 
         // when
         List<AnswerResponse> actualAnswerResponses = answerService.toAnswerResponses(expectedAnswers);

--- a/backend/src/test/java/com/cruru/applicant/controller/ApplicantControllerTest.java
+++ b/backend/src/test/java/com/cruru/applicant/controller/ApplicantControllerTest.java
@@ -33,7 +33,7 @@ class ApplicantControllerTest extends ControllerTest {
 
     @DisplayName("지원자들의 프로세스를 일괄적으로 옮기는 데 성공하면 200을 응답한다.")
     @Test
-    void updateApplicantProcess() {
+    void updateInformationApplicantProcess() {
         // given
         Process now = processRepository.save(ProcessFixture.createFirstProcess());
         Process next = processRepository.save(ProcessFixture.createFinalProcess());
@@ -77,7 +77,7 @@ class ApplicantControllerTest extends ControllerTest {
 
     @DisplayName("지원자를 불합격시키는 데 성공하면 200을 응답한다.")
     @Test
-    void reject() {
+    void updateReject() {
         // given
         Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby());
 
@@ -89,7 +89,7 @@ class ApplicantControllerTest extends ControllerTest {
 
     @DisplayName("지원자 정보 변경에 성공하면 200을 응답한다.")
     @Test
-    void update() {
+    void updateInformation() {
         // given
         String toChangeName = "도비";
         String toChangeEmail = "dev.dobby@gmail.com";

--- a/backend/src/test/java/com/cruru/applicant/controller/ApplicantControllerTest.java
+++ b/backend/src/test/java/com/cruru/applicant/controller/ApplicantControllerTest.java
@@ -1,10 +1,5 @@
 package com.cruru.applicant.controller;
 
-import static com.cruru.util.fixture.ApplicantFixture.createPendingApplicantDobby;
-import static com.cruru.util.fixture.DashboardFixture.createBackendDashboard;
-import static com.cruru.util.fixture.ProcessFixture.createFinalProcess;
-import static com.cruru.util.fixture.ProcessFixture.createFirstProcess;
-
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
 import com.cruru.applicant.domain.Applicant;
@@ -15,6 +10,8 @@ import com.cruru.process.domain.Process;
 import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.util.ControllerTest;
 import com.cruru.util.fixture.ApplicantFixture;
+import com.cruru.util.fixture.DashboardFixture;
+import com.cruru.util.fixture.ProcessFixture;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.List;
@@ -38,8 +35,8 @@ class ApplicantControllerTest extends ControllerTest {
     @Test
     void updateApplicantProcess() {
         // given
-        Process now = processRepository.save(createFirstProcess());
-        Process next = processRepository.save(createFinalProcess());
+        Process now = processRepository.save(ProcessFixture.createFirstProcess());
+        Process next = processRepository.save(ProcessFixture.createFinalProcess());
         Applicant applicant = ApplicantFixture.createPendingApplicantDobby(now);
         applicantRepository.save(applicant);
 
@@ -55,8 +52,8 @@ class ApplicantControllerTest extends ControllerTest {
     @Test
     void read() {
         // given
-        Process process = processRepository.save(createFirstProcess());
-        Applicant applicant = applicantRepository.save(createPendingApplicantDobby(process));
+        Process process = processRepository.save(ProcessFixture.createFirstProcess());
+        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby(process));
 
         // when&then
         RestAssured.given().log().all()
@@ -68,9 +65,9 @@ class ApplicantControllerTest extends ControllerTest {
     @Test
     void readDetail() {
         // given
-        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
-        Process process = processRepository.save(createFirstProcess(dashboard));
-        Applicant applicant = applicantRepository.save(createPendingApplicantDobby(process));
+        Dashboard dashboard = dashboardRepository.save(DashboardFixture.createBackendDashboard());
+        Process process = processRepository.save(ProcessFixture.createFirstProcess(dashboard));
+        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby(process));
 
         // when&then
         RestAssured.given().log().all()
@@ -97,7 +94,7 @@ class ApplicantControllerTest extends ControllerTest {
         String toChangeName = "도비";
         String toChangeEmail = "dev.dobby@gmail.com";
         String toChangePhone = "010111111111";
-        Applicant applicant = applicantRepository.save(createPendingApplicantDobby());
+        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby());
         ApplicantUpdateRequest request = new ApplicantUpdateRequest(toChangeName, toChangeEmail, toChangePhone);
 
         // when&then

--- a/backend/src/test/java/com/cruru/applicant/controller/ApplicantControllerTest.java
+++ b/backend/src/test/java/com/cruru/applicant/controller/ApplicantControllerTest.java
@@ -33,7 +33,7 @@ class ApplicantControllerTest extends ControllerTest {
 
     @DisplayName("지원자들의 프로세스를 일괄적으로 옮기는 데 성공하면 200을 응답한다.")
     @Test
-    void updateInformationApplicantProcess() {
+    void updateProcess() {
         // given
         Process now = processRepository.save(ProcessFixture.createFirstProcess());
         Process next = processRepository.save(ProcessFixture.createFinalProcess());

--- a/backend/src/test/java/com/cruru/applicant/domain/ApplicantTest.java
+++ b/backend/src/test/java/com/cruru/applicant/domain/ApplicantTest.java
@@ -1,5 +1,8 @@
 package com.cruru.applicant.domain;
 
+import static com.cruru.applicant.domain.ApplicantState.APPROVED;
+import static com.cruru.applicant.domain.ApplicantState.PENDING;
+import static com.cruru.applicant.domain.ApplicantState.REJECTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -30,5 +33,54 @@ class ApplicantTest {
                 () -> assertThat(applicant.getPhone()).isEqualTo(toChangePhone),
                 () -> assertThat(applicant.getProcess()).isNull()
         );
+    }
+
+    @DisplayName("지원자의 상태를 REJECTED로 업데이트한다.")
+    @Test
+    void reject() {
+        // given
+        Applicant applicant = ApplicantFixture.createPendingApplicantDobby();
+
+        // when
+        applicant.reject();
+
+        // then
+        assertAll(() -> {
+            assertThat(applicant.getState()).isEqualTo(REJECTED);
+            assertThat(applicant.isRejected()).isTrue();
+        });
+    }
+
+    @DisplayName("지원자의 상태를 PENDING로 업데이트한다.")
+    @Test
+    void pending() {
+        // given
+        Applicant applicant = ApplicantFixture.createPendingApplicantDobby();
+        applicant.reject();
+
+        // when
+        applicant.pending();
+
+        // then
+        assertAll(() -> {
+            assertThat(applicant.getState()).isEqualTo(PENDING);
+            assertThat(applicant.isPending()).isTrue();
+        });
+    }
+
+    @DisplayName("지원자의 상태를 APPROVE로 업데이트한다.")
+    @Test
+    void approve() {
+        // given
+        Applicant applicant = ApplicantFixture.createPendingApplicantDobby();
+
+        // when
+        applicant.approve();
+
+        // then
+        assertAll(() -> {
+            assertThat(applicant.getState()).isEqualTo(APPROVED);
+            assertThat(applicant.isApproved()).isTrue();
+        });
     }
 }

--- a/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
+++ b/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
@@ -106,9 +106,9 @@ class ApplicantServiceTest extends ServiceTest {
         Long applicantId = applicant.getId();
 
         // when & then
-        assertThatThrownBy(() -> {
-            applicantService.updateApplicantInformation(applicantId, noChangeRequest);
-        }).isInstanceOf(ApplicantNoChangeException.class);
+        assertThatThrownBy(
+                () -> applicantService.updateApplicantInformation(applicantId, noChangeRequest)
+        ).isInstanceOf(ApplicantNoChangeException.class);
     }
 
     @DisplayName("여러 건의 지원서를 요청된 프로세스로 일괄 변경한다.")

--- a/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
+++ b/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
@@ -1,29 +1,24 @@
 package com.cruru.applicant.service;
 
+import static com.cruru.applicant.domain.ApplicantState.REJECTED;
 import static com.cruru.util.fixture.ApplicantFixture.createPendingApplicantDobby;
 import static com.cruru.util.fixture.DashboardFixture.createBackendDashboard;
 import static com.cruru.util.fixture.ProcessFixture.createFinalProcess;
 import static com.cruru.util.fixture.ProcessFixture.createFirstProcess;
-import static com.cruru.util.fixture.QuestionFixture.createShortAnswerQuestion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.cruru.answer.domain.Answer;
-import com.cruru.answer.domain.repository.AnswerRepository;
-import com.cruru.applicant.controller.dto.ApplicantDetailResponse;
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
-import com.cruru.applicant.controller.dto.QnaResponse;
+import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.applicant.exception.ApplicantNotFoundException;
+import com.cruru.applicant.exception.badrequest.ApplicantNoChangeException;
 import com.cruru.applicant.exception.badrequest.ApplicantRejectException;
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.dashboard.domain.repository.DashboardRepository;
 import com.cruru.process.domain.Process;
 import com.cruru.process.domain.repository.ProcessRepository;
-import com.cruru.question.domain.Question;
-import com.cruru.question.domain.repository.QuestionRepository;
 import com.cruru.util.ServiceTest;
 import com.cruru.util.fixture.ApplicantFixture;
 import jakarta.persistence.EntityManager;
@@ -48,128 +43,7 @@ class ApplicantServiceTest extends ServiceTest {
     private DashboardRepository dashboardRepository;
 
     @Autowired
-    private QuestionRepository questionRepository;
-
-    @Autowired
-    private AnswerRepository answerRepository;
-
-    @Autowired
     private EntityManager entityManager;
-
-    @DisplayName("여러 건의 지원서를 요청된 프로세스로 일괄 변경한다.")
-    @Test
-    void updateApplicantProcess() {
-        // given
-        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
-        Process beforeProcess = processRepository.save(createFirstProcess(dashboard));
-        Process afterProcess = processRepository.save(createFinalProcess(dashboard));
-
-        List<Applicant> applicants = applicantRepository.saveAll(List.of(
-                createPendingApplicantDobby(beforeProcess),
-                createPendingApplicantDobby(beforeProcess)
-        ));
-        List<Long> applicantIds = applicants.stream()
-                .map(Applicant::getId)
-                .toList();
-        ApplicantMoveRequest moveRequest = new ApplicantMoveRequest(applicantIds);
-
-        // when
-        applicantService.updateApplicantProcess(afterProcess.getId(), moveRequest);
-
-        // then
-        List<Applicant> actualApplicants = entityManager.createQuery(
-                        "SELECT a FROM Applicant a JOIN FETCH a.process", Applicant.class)
-                .getResultList();
-        assertThat(actualApplicants).allMatch(applicant -> applicant.getProcess().equals(afterProcess));
-    }
-
-    //    @DisplayName("id로 지원자를 찾는다.")
-    //    @Test
-    //    void findById() {
-    //        // given
-    //        Process process = processRepository.save(createFirstProcess());
-    //        Applicant applicant = applicantRepository.save(createPendingApplicantDobby(process));
-    //
-    //        // when
-    //        ApplicantBasicResponse basicResponse = applicantService.findById(applicant.getId());
-    //        ProcessSimpleResponse processResponse = basicResponse.processResponse();
-    //        ApplicantResponse applicantResponse = basicResponse.applicantResponse();
-    //
-    //        // then
-    //        assertAll(
-    //                () -> assertThat(process.getId()).isEqualTo(processResponse.id()),
-    //                () -> assertThat(process.getName()).isEqualTo(processResponse.name()),
-    //                () -> assertThat(applicant.getId()).isEqualTo(applicantResponse.id()),
-    //                () -> assertThat(applicant.getName()).isEqualTo(applicantResponse.name()),
-    //                () -> assertThat(applicant.getEmail()).isEqualTo(applicantResponse.email()),
-    //                () -> assertThat(applicant.getPhone()).isEqualTo(applicantResponse.phone())
-    //        );
-    //    }
-
-    @DisplayName("id에 해당하는 지원자가 존재하지 않으면 Not Found 예외가 발생한다.")
-    @Test
-    void findById_notFound() {
-        // given
-        long invalidId = -1L;
-
-        // when&then
-        assertThatThrownBy(() -> applicantService.findById(invalidId))
-                .isInstanceOf(ApplicantNotFoundException.class);
-    }
-
-    @DisplayName("id로 지원자의 상세 정보를 찾는다.")
-    @Test
-    void findDetailById() {
-        // given
-        Dashboard dashboard = createBackendDashboard();
-        dashboardRepository.save(dashboard);
-        Process process = createFirstProcess(dashboard);
-        processRepository.save(process);
-        Applicant applicant = createPendingApplicantDobby(process);
-        applicantRepository.save(applicant);
-
-        Question question = questionRepository.save(createShortAnswerQuestion(null));
-        questionRepository.save(question);
-        Answer answer = new Answer("토끼", question, applicant);
-        answerRepository.save(answer);
-
-        // when
-        ApplicantDetailResponse applicantDetailResponse = applicantService.findDetailById(applicant.getId());
-
-        //then
-        List<QnaResponse> qnaResponses = applicantDetailResponse.qnaResponses();
-        assertAll(
-                () -> assertThat(qnaResponses.get(0).question()).isEqualTo(question.getContent()),
-                () -> assertThat(qnaResponses.get(0).answer()).isEqualTo(answer.getContent())
-        );
-    }
-
-    @DisplayName("id로 지원자를 불합격시킨다.")
-    @Test
-    void reject() {
-        // given
-        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby());
-
-        // when
-        applicantService.reject(applicant.getId());
-
-        // then
-        assertThat(applicantRepository.findById(applicant.getId()).get().isRejected()).isTrue();
-    }
-
-    @DisplayName("이미 불합격한 지원자를 불합격시키려 하면 예외가 발생한다.")
-    @Test
-    void reject_alreadyRejected() {
-        // given
-        Applicant targetApplicant = createPendingApplicantDobby();
-        targetApplicant.reject();
-        Applicant rejectedApplicant = applicantRepository.save(targetApplicant);
-
-        // when&then
-        Long applicantId = rejectedApplicant.getId();
-        assertThatThrownBy(() -> applicantService.reject(applicantId))
-                .isInstanceOf(ApplicantRejectException.class);
-    }
 
     @DisplayName("프로세스 내의 모든 지원자를 조회한다.")
     @Test
@@ -186,5 +60,87 @@ class ApplicantServiceTest extends ServiceTest {
 
         // then
         assertThat(applicantsInProcess).containsExactlyElementsOf(applicants);
+    }
+
+    @DisplayName("id에 해당하는 지원자가 존재하지 않으면 Not Found 예외가 발생한다.")
+    @Test
+    void findById_notFound() {
+        // given
+        long invalidId = -1L;
+
+        // when&then
+        assertThatThrownBy(() -> applicantService.findById(invalidId)).isInstanceOf(ApplicantNotFoundException.class);
+    }
+
+    @DisplayName("지원자의 정보 변경 요청의 이름, 이메일, 전화번호 변경점이 없다면 예외를 던진다")
+    @Test
+    void updateApplicantInformation() {
+        // given
+        Applicant applicant = ApplicantFixture.createPendingApplicantDobby();
+        String originalName = applicant.getName();
+        String originalEmail = applicant.getEmail();
+        String originalPhone = applicant.getPhone();
+        ApplicantUpdateRequest noChangeRequest = new ApplicantUpdateRequest(originalName, originalEmail, originalPhone);
+
+        // when
+        Applicant savedApplicant = applicantRepository.save(applicant);
+
+        // then
+        assertThatThrownBy(() -> applicantService.updateApplicantInformation(noChangeRequest,
+                savedApplicant
+        )).isInstanceOf(ApplicantNoChangeException.class);
+    }
+
+    @DisplayName("여러 건의 지원서를 요청된 프로세스로 일괄 변경한다.")
+    @Test
+    void moveApplicantProcess() {
+        // given
+        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
+        Process beforeProcess = processRepository.save(createFirstProcess(dashboard));
+        Process afterProcess = processRepository.save(createFinalProcess(dashboard));
+
+        List<Applicant> applicants = applicantRepository.saveAll(List.of(createPendingApplicantDobby(beforeProcess),
+                createPendingApplicantDobby(beforeProcess)
+        ));
+        List<Long> applicantIds = applicants.stream()
+                .map(Applicant::getId)
+                .toList();
+        ApplicantMoveRequest moveRequest = new ApplicantMoveRequest(applicantIds);
+
+        // when
+        applicantService.moveApplicantProcess(afterProcess, moveRequest);
+
+        // then
+        List<Applicant> actualApplicants = entityManager.createQuery("SELECT a FROM Applicant a JOIN FETCH a.process",
+                Applicant.class
+        ).getResultList();
+        assertThat(actualApplicants).allMatch(applicant -> applicant.getProcess().equals(afterProcess));
+    }
+
+    @DisplayName("특정 지원자의 상태를 불합격으로 변경한다.")
+    @Test
+    void reject() {
+        // given
+        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby());
+
+        // when
+        applicantService.reject(applicant.getId());
+
+        // then
+        Applicant rejectedApplicant = applicantRepository.findById(applicant.getId()).get();
+        assertThat(rejectedApplicant.getState()).isEqualTo(REJECTED);
+    }
+
+    @DisplayName("이미 불합격한 지원자를 불합격시키려 하면 예외가 발생한다.")
+    @Test
+    void reject_alreadyRejected() {
+        // given
+        Applicant targetApplicant = createPendingApplicantDobby();
+        targetApplicant.reject();
+        Applicant rejectedApplicant = applicantRepository.save(targetApplicant);
+
+        // when&then
+        Long applicantId = rejectedApplicant.getId();
+        assertThatThrownBy(() -> applicantService.reject(applicantId)).isInstanceOf(ApplicantRejectException.class);
     }
 }

--- a/backend/src/test/java/com/cruru/applicant/service/facade/ApplicantFacadeTest.java
+++ b/backend/src/test/java/com/cruru/applicant/service/facade/ApplicantFacadeTest.java
@@ -1,0 +1,172 @@
+package com.cruru.applicant.service.facade;
+
+import static com.cruru.applicant.domain.ApplicantState.REJECTED;
+import static com.cruru.util.fixture.ApplicantFixture.createPendingApplicantDobby;
+import static com.cruru.util.fixture.DashboardFixture.createBackendDashboard;
+import static com.cruru.util.fixture.ProcessFixture.createFinalProcess;
+import static com.cruru.util.fixture.ProcessFixture.createFirstProcess;
+import static com.cruru.util.fixture.QuestionFixture.createShortAnswerQuestion;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.cruru.answer.domain.Answer;
+import com.cruru.answer.domain.repository.AnswerRepository;
+import com.cruru.applicant.controller.dto.ApplicantBasicResponse;
+import com.cruru.applicant.controller.dto.ApplicantDetailResponse;
+import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
+import com.cruru.applicant.controller.dto.ApplicantResponse;
+import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
+import com.cruru.applicant.controller.dto.QnaResponse;
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.domain.repository.ApplicantRepository;
+import com.cruru.dashboard.domain.Dashboard;
+import com.cruru.dashboard.domain.repository.DashboardRepository;
+import com.cruru.process.controller.dto.ProcessSimpleResponse;
+import com.cruru.process.domain.Process;
+import com.cruru.process.domain.repository.ProcessRepository;
+import com.cruru.question.domain.Question;
+import com.cruru.question.domain.repository.QuestionRepository;
+import com.cruru.util.ServiceTest;
+import com.cruru.util.fixture.ApplicantFixture;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("지원자 파사드 서비스 테스트")
+class ApplicantFacadeTest extends ServiceTest {
+
+    @Autowired
+    private ApplicantFacade applicantFacade;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
+
+    @Autowired
+    private ProcessRepository processRepository;
+
+    @Autowired
+    private DashboardRepository dashboardRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private AnswerRepository answerRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @DisplayName("Id로 지원자의 기본 정보를 조회한다.")
+    @Test
+    void readBasicById() {
+        // given
+        Process process = processRepository.save(createFirstProcess());
+        Applicant applicant = applicantRepository.save(createPendingApplicantDobby(process));
+
+        // when
+        ApplicantBasicResponse basicResponse = applicantFacade.readBasicById(applicant.getId());
+        ProcessSimpleResponse processResponse = basicResponse.processResponse();
+        ApplicantResponse applicantResponse = basicResponse.applicantResponse();
+
+        // then
+        assertAll(() -> assertThat(process.getId()).isEqualTo(processResponse.id()),
+                () -> assertThat(process.getName()).isEqualTo(processResponse.name()),
+                () -> assertThat(applicant.getId()).isEqualTo(applicantResponse.id()),
+                () -> assertThat(applicant.getName()).isEqualTo(applicantResponse.name()),
+                () -> assertThat(applicant.getEmail()).isEqualTo(applicantResponse.email()),
+                () -> assertThat(applicant.getPhone()).isEqualTo(applicantResponse.phone())
+        );
+    }
+
+    @DisplayName("id로 지원자의 상세 정보를 찾는다.")
+    @Test
+    void readDetailById() {
+        // given
+        Dashboard dashboard = createBackendDashboard();
+        dashboardRepository.save(dashboard);
+        Process process = createFirstProcess(dashboard);
+        processRepository.save(process);
+        Applicant applicant = createPendingApplicantDobby(process);
+        applicantRepository.save(applicant);
+
+        Question question = questionRepository.save(createShortAnswerQuestion(null));
+        questionRepository.save(question);
+        Answer answer = new Answer("토끼", question, applicant);
+        answerRepository.save(answer);
+
+        // when
+        ApplicantDetailResponse applicantDetailResponse = applicantFacade.readDetailById(applicant.getId());
+
+        //then
+        List<QnaResponse> qnaResponses = applicantDetailResponse.qnaResponses();
+        assertAll(() -> assertThat(qnaResponses.get(0).question()).isEqualTo(question.getContent()),
+                () -> assertThat(qnaResponses.get(0).answer()).isEqualTo(answer.getContent())
+        );
+    }
+
+    @DisplayName("지원자의 이름, 이메일, 전화번호를 변경한다.")
+    @Test
+    void updateApplicantInformation() {
+        // given
+        Applicant applicant = ApplicantFixture.createPendingApplicantDobby();
+        String changedName = "수정된 이름";
+        String changedEmail = "modified@email.com";
+        String changedPhone = "01099999999";
+        ApplicantUpdateRequest changeRequest = new ApplicantUpdateRequest(changedName, changedEmail, changedPhone);
+        Applicant savedApplicant = applicantRepository.save(applicant);
+        Long applicantId = savedApplicant.getId();
+
+        // when
+        applicantFacade.updateApplicantInformation(changeRequest, applicantId);
+
+        // then
+        Applicant actualApplicant = applicantRepository.findById(applicantId).get();
+        assertAll(() -> {
+            assertThat(actualApplicant.getName()).isEqualTo(changedName);
+            assertThat(actualApplicant.getEmail()).isEqualTo(changedEmail);
+            assertThat(actualApplicant.getPhone()).isEqualTo(changedPhone);
+        });
+    }
+
+    @DisplayName("복수의 지원서들을 요청된 프로세스로 일괄 업데이트한다.")
+    @Test
+    void updateApplicantProcess() {
+        // given
+        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
+        Process beforeProcess = processRepository.save(createFirstProcess(dashboard));
+        Process afterProcess = processRepository.save(createFinalProcess(dashboard));
+
+        List<Applicant> applicants = applicantRepository.saveAll(List.of(createPendingApplicantDobby(beforeProcess),
+                createPendingApplicantDobby(beforeProcess)
+        ));
+        List<Long> applicantIds = applicants.stream()
+                .map(Applicant::getId)
+                .toList();
+        ApplicantMoveRequest moveRequest = new ApplicantMoveRequest(applicantIds);
+
+        // when
+        applicantFacade.updateApplicantProcess(afterProcess.getId(), moveRequest);
+
+        // then
+        List<Applicant> actualApplicants = entityManager.createQuery("SELECT a FROM Applicant a JOIN FETCH a.process",
+                Applicant.class
+        ).getResultList();
+        assertThat(actualApplicants).allMatch(applicant -> applicant.getProcess().equals(afterProcess));
+    }
+
+    @DisplayName("특정 지원자의 상태를 불합격으로 변경한다.")
+    @Test
+    void updateApplicantToReject() {
+        // given
+        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby());
+
+        // when
+        applicantFacade.updateApplicantToReject(applicant.getId());
+
+        // then
+        Applicant rejectedApplicant = applicantRepository.findById(applicant.getId()).get();
+        assertThat(rejectedApplicant.getState()).isEqualTo(REJECTED);
+    }
+}

--- a/backend/src/test/java/com/cruru/applicant/service/facade/ApplicantFacadeTest.java
+++ b/backend/src/test/java/com/cruru/applicant/service/facade/ApplicantFacadeTest.java
@@ -6,12 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.cruru.answer.domain.Answer;
 import com.cruru.answer.domain.repository.AnswerRepository;
+import com.cruru.answer.dto.AnswerResponse;
+import com.cruru.applicant.controller.dto.ApplicantAnswerResponses;
 import com.cruru.applicant.controller.dto.ApplicantBasicResponse;
-import com.cruru.applicant.controller.dto.ApplicantDetailResponse;
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantResponse;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
-import com.cruru.applicant.controller.dto.QnaResponse;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.dashboard.domain.Dashboard;
@@ -69,14 +69,14 @@ class ApplicantFacadeTest extends ServiceTest {
         ApplicantResponse applicantResponse = basicResponse.applicantResponse();
 
         // then
-        assertAll(
-                () -> assertThat(processResponse.id()).isEqualTo(process.getId()),
-                () -> assertThat(processResponse.name()).isEqualTo(process.getName()),
-                () -> assertThat(applicantResponse.id()).isEqualTo(applicant.getId()),
-                () -> assertThat(applicantResponse.name()).isEqualTo(applicant.getName()),
-                () -> assertThat(applicantResponse.email()).isEqualTo(applicant.getEmail()),
-                () -> assertThat(applicantResponse.phone()).isEqualTo(applicant.getPhone())
-        );
+        assertAll(() -> {
+            assertThat(processResponse.id()).isEqualTo(process.getId());
+            assertThat(processResponse.name()).isEqualTo(process.getName());
+            assertThat(applicantResponse.id()).isEqualTo(applicant.getId());
+            assertThat(applicantResponse.name()).isEqualTo(applicant.getName());
+            assertThat(applicantResponse.email()).isEqualTo(applicant.getEmail());
+            assertThat(applicantResponse.phone()).isEqualTo(applicant.getPhone());
+        });
     }
 
     @DisplayName("id로 지원자의 상세 정보를 찾는다.")
@@ -96,14 +96,14 @@ class ApplicantFacadeTest extends ServiceTest {
         answerRepository.save(answer);
 
         // when
-        ApplicantDetailResponse applicantDetailResponse = applicantFacade.readDetailById(applicant.getId());
+        ApplicantAnswerResponses applicantAnswerResponses = applicantFacade.readDetailById(applicant.getId());
 
         //then
-        List<QnaResponse> qnaResponses = applicantDetailResponse.qnaResponses();
-        assertAll(
-                () -> assertThat(qnaResponses.get(0).question()).isEqualTo(question.getContent()),
-                () -> assertThat(qnaResponses.get(0).answer()).isEqualTo(answer.getContent())
-        );
+        List<AnswerResponse> answerResponses = applicantAnswerResponses.answerResponses();
+        assertAll(() -> {
+            assertThat(answerResponses.get(0).question()).isEqualTo(question.getContent());
+            assertThat(answerResponses.get(0).answer()).isEqualTo(answer.getContent());
+        });
     }
 
     @DisplayName("지원자의 이름, 이메일, 전화번호를 변경한다.")
@@ -119,7 +119,7 @@ class ApplicantFacadeTest extends ServiceTest {
         Long applicantId = savedApplicant.getId();
 
         // when
-        applicantFacade.updateApplicantInformation(changeRequest, applicantId);
+        applicantFacade.updateApplicantInformation(applicantId, changeRequest);
 
         // then
         Applicant actualApplicant = applicantRepository.findById(applicantId).get();

--- a/backend/src/test/java/com/cruru/applicant/service/facade/ApplicantFacadeTest.java
+++ b/backend/src/test/java/com/cruru/applicant/service/facade/ApplicantFacadeTest.java
@@ -22,6 +22,7 @@ import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.question.domain.Question;
 import com.cruru.question.domain.repository.QuestionRepository;
 import com.cruru.util.ServiceTest;
+import com.cruru.util.fixture.AnswerFixture;
 import com.cruru.util.fixture.ApplicantFixture;
 import com.cruru.util.fixture.DashboardFixture;
 import com.cruru.util.fixture.ProcessFixture;
@@ -92,7 +93,7 @@ class ApplicantFacadeTest extends ServiceTest {
 
         Question question = questionRepository.save(QuestionFixture.createShortAnswerQuestion(null));
         questionRepository.save(question);
-        Answer answer = new Answer("토끼", question, applicant);
+        Answer answer = AnswerFixture.shortAnswer(question, applicant);
         answerRepository.save(answer);
 
         // when

--- a/backend/src/test/java/com/cruru/util/fixture/AnswerFixture.java
+++ b/backend/src/test/java/com/cruru/util/fixture/AnswerFixture.java
@@ -13,4 +13,8 @@ public class AnswerFixture {
     public static Answer secondAnswer(Question question, Applicant applicant) {
         return new Answer("응답2", question, applicant);
     }
+
+    public static Answer shortAnswer(Question question, Applicant applicant) {
+        return new Answer("단답", question, applicant);
+    }
 }

--- a/backend/src/test/java/com/cruru/util/fixture/AnswerFixture.java
+++ b/backend/src/test/java/com/cruru/util/fixture/AnswerFixture.java
@@ -1,0 +1,16 @@
+package com.cruru.util.fixture;
+
+import com.cruru.answer.domain.Answer;
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.question.domain.Question;
+
+public class AnswerFixture {
+
+    public static Answer fristAnswer(Question question, Applicant applicant) {
+        return new Answer("응답1", question, applicant);
+    }
+
+    public static Answer secondAnswer(Question question, Applicant applicant) {
+        return new Answer("응답2", question, applicant);
+    }
+}


### PR DESCRIPTION
- #315 

## 목적

Applicant 도메인에 Facade Service를 도입합니다.


## 작업 세부사항
- [x] Applicant 도메인 관련 Service 로직 분리
- [x] Test 수정 및 작성

## 참고 사항
bottom-up 방식으로 ERD상 하위 엔티티 도메인부터 작업을 진행해나갈 예정입니다.
완료된 PR의 경우 cherry-pick 또는 merge를 통해 본인의 코드에 적용해주세요



FACADE_ADOPTION_01-3