### PR TITLE
refactor-be(Process): Facade Service 계층 도입

### DIFF
--- a/backend/src/main/java/com/cruru/answer/service/AnswerService.java
+++ b/backend/src/main/java/com/cruru/answer/service/AnswerService.java
@@ -4,6 +4,7 @@ import com.cruru.answer.domain.Answer;
 import com.cruru.answer.domain.repository.AnswerRepository;
 import com.cruru.answer.dto.AnswerResponse;
 import com.cruru.applicant.domain.Applicant;
+import com.cruru.applyform.controller.dto.AnswerCreateRequest;
 import com.cruru.question.domain.Question;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnswerService {
 
     private final AnswerRepository answerRepository;
+
+    @Transactional
+    public void saveAnswerReplies(AnswerCreateRequest answerCreateRequest, Question question, Applicant applicant) {
+        for (String reply : answerCreateRequest.replies()) {
+            Answer answer = new Answer(reply, question, applicant);
+            answerRepository.save(answer);
+        }
+    }
 
     public List<Answer> findAllByApplicant(Applicant applicant) {
         return answerRepository.findAllByApplicant(applicant);

--- a/backend/src/main/java/com/cruru/applicant/controller/dto/ApplicantCardResponse.java
+++ b/backend/src/main/java/com/cruru/applicant/controller/dto/ApplicantCardResponse.java
@@ -3,8 +3,9 @@ package com.cruru.applicant.controller.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 
-public record DashboardApplicantResponse(
-        long applicantId,
+public record ApplicantCardResponse(
+        @JsonProperty("processId")
+        long id,
 
         @JsonProperty("applicantName")
         String name,

--- a/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
+++ b/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
@@ -1,6 +1,7 @@
 package com.cruru.applicant.service;
 
 import com.cruru.applicant.controller.dto.ApplicantCardResponse;
+import com.cruru.applicant.controller.dto.ApplicantCreateRequest;
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantResponse;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
@@ -22,6 +23,11 @@ public class ApplicantService {
 
     private final ApplicantRepository applicantRepository;
 
+    @Transactional
+    public Applicant create(ApplicantCreateRequest request, Process firstProcess) {
+        return applicantRepository.save(new Applicant(request.name(), request.email(), request.phone(), firstProcess));
+    }
+
     public List<Applicant> findAllByProcess(Process process) {
         return applicantRepository.findAllByProcess(process);
     }
@@ -41,8 +47,7 @@ public class ApplicantService {
     }
 
     private boolean notChangedInformation(ApplicantUpdateRequest request, Applicant applicant) {
-        return applicant.getName().equals(request.name())
-                && applicant.getEmail().equals(request.email())
+        return applicant.getName().equals(request.name()) && applicant.getEmail().equals(request.email())
                 && applicant.getPhone().equals(request.phone());
     }
 

--- a/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
+++ b/backend/src/main/java/com/cruru/applicant/service/ApplicantService.java
@@ -1,5 +1,6 @@
 package com.cruru.applicant.service;
 
+import com.cruru.applicant.controller.dto.ApplicantCardResponse;
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantResponse;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
@@ -71,6 +72,16 @@ public class ApplicantService {
                 applicant.getEmail(),
                 applicant.getPhone(),
                 applicant.getCreatedDate()
+        );
+    }
+
+    public ApplicantCardResponse toApplicantCardResponse(Applicant applicant, int evaluationCount) {
+        return new ApplicantCardResponse(
+                applicant.getId(),
+                applicant.getName(),
+                applicant.getCreatedDate(),
+                applicant.isRejected(),
+                evaluationCount
         );
     }
 }

--- a/backend/src/main/java/com/cruru/applyform/controller/ApplyFormController.java
+++ b/backend/src/main/java/com/cruru/applyform/controller/ApplyFormController.java
@@ -2,7 +2,6 @@ package com.cruru.applyform.controller;
 
 import com.cruru.applyform.controller.dto.ApplyFormResponse;
 import com.cruru.applyform.controller.dto.ApplyFormSubmitRequest;
-import com.cruru.applyform.service.ApplyFormService;
 import com.cruru.applyform.service.facade.ApplyFormFacade;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -21,20 +20,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class ApplyFormController {
 
     private final ApplyFormFacade applyFormFacade;
-    private final ApplyFormService applyFormService;
 
     @PostMapping("/{applyformId}/submit")
     public ResponseEntity<Void> submit(
             @RequestBody @Valid ApplyFormSubmitRequest request,
             @PathVariable("applyformId") long applyFormId
     ) {
-        applyFormService.submit(request, applyFormId);
+        applyFormFacade.submit(applyFormId, request);
         return ResponseEntity.created(URI.create("/v1/applyform/" + applyFormId)).build();
     }
 
     @GetMapping("/{applyformId}")
     public ResponseEntity<ApplyFormResponse> read(@PathVariable("applyformId") long applyFormId) {
-        ApplyFormResponse response = applyFormFacade.findApplyFormById(applyFormId);
+        ApplyFormResponse response = applyFormFacade.readApplyFormById(applyFormId);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/cruru/applyform/domain/repository/ApplyFormRepository.java
+++ b/backend/src/main/java/com/cruru/applyform/domain/repository/ApplyFormRepository.java
@@ -1,10 +1,11 @@
 package com.cruru.applyform.domain.repository;
 
 import com.cruru.applyform.domain.ApplyForm;
+import com.cruru.dashboard.domain.Dashboard;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ApplyFormRepository extends JpaRepository<ApplyForm, Long> {
 
-    Optional<ApplyForm> findByDashboardId(long dashboardId);
+    Optional<ApplyForm> findByDashboard(Dashboard dashboardId);
 }

--- a/backend/src/main/java/com/cruru/applyform/exception/badrequest/PersonalDataCollectDisagreeException.java
+++ b/backend/src/main/java/com/cruru/applyform/exception/badrequest/PersonalDataCollectDisagreeException.java
@@ -2,11 +2,11 @@ package com.cruru.applyform.exception.badrequest;
 
 import com.cruru.advice.badrequest.BadRequestException;
 
-public class PersonalDataProcessingException extends BadRequestException {
+public class PersonalDataCollectDisagreeException extends BadRequestException {
 
     private static final String TEXT = "개인 정보 수집에 동의하지 않았습니다.";
 
-    public PersonalDataProcessingException() {
+    public PersonalDataCollectDisagreeException() {
         super(TEXT);
     }
 }

--- a/backend/src/main/java/com/cruru/applyform/service/ApplyFormService.java
+++ b/backend/src/main/java/com/cruru/applyform/service/ApplyFormService.java
@@ -159,8 +159,8 @@ public class ApplyFormService {
                 .orElseThrow(ApplyFormNotFoundException::new);
     }
 
-    public ApplyForm findByDashboardId(long dashboardId) {
-        return applyFormRepository.findByDashboardId(dashboardId)
+    public ApplyForm findByDashboard(Dashboard dashboard) {
+        return applyFormRepository.findByDashboard(dashboard)
                 .orElseThrow(ApplyFormNotFoundException::new);
     }
 }

--- a/backend/src/main/java/com/cruru/applyform/service/ApplyFormService.java
+++ b/backend/src/main/java/com/cruru/applyform/service/ApplyFormService.java
@@ -1,30 +1,10 @@
 package com.cruru.applyform.service;
 
-import com.cruru.advice.InternalServerException;
-import com.cruru.answer.domain.Answer;
-import com.cruru.answer.domain.repository.AnswerRepository;
-import com.cruru.applicant.domain.Applicant;
-import com.cruru.applicant.domain.repository.ApplicantRepository;
-import com.cruru.applyform.controller.dto.AnswerCreateRequest;
 import com.cruru.applyform.controller.dto.ApplyFormCreateRequest;
-import com.cruru.applyform.controller.dto.ApplyFormResponse;
-import com.cruru.applyform.controller.dto.ApplyFormSubmitRequest;
 import com.cruru.applyform.domain.ApplyForm;
 import com.cruru.applyform.domain.repository.ApplyFormRepository;
 import com.cruru.applyform.exception.ApplyFormNotFoundException;
-import com.cruru.applyform.exception.badrequest.PersonalDataProcessingException;
-import com.cruru.choice.controller.dto.ChoiceResponse;
-import com.cruru.choice.domain.Choice;
-import com.cruru.choice.domain.repository.ChoiceRepository;
 import com.cruru.dashboard.domain.Dashboard;
-import com.cruru.process.domain.Process;
-import com.cruru.process.domain.repository.ProcessRepository;
-import com.cruru.question.controller.dto.QuestionResponse;
-import com.cruru.question.domain.Question;
-import com.cruru.question.domain.repository.QuestionRepository;
-import com.cruru.question.exception.QuestionNotFoundException;
-import java.util.Collections;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,22 +14,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ApplyFormService {
 
-    private static final String APPLY_FORM_BASE_URL = "www.cruru.kr/applyform/";
+    private static final String APPLY_POST_BASE_URL = "www.cruru.kr/post/%d";
 
-    private final ApplicantRepository applicantRepository;
-    private final AnswerRepository answerRepository;
-    private final QuestionRepository questionRepository;
     private final ApplyFormRepository applyFormRepository;
-    private final ProcessRepository processRepository;
-    private final ChoiceRepository choiceRepository;
 
     @Transactional
     public ApplyForm create(ApplyFormCreateRequest request, Dashboard createdDashboard) {
         ApplyForm applyForm = toApplyForm(request, createdDashboard);
 
         ApplyForm savedApplyForm = applyFormRepository.save(applyForm);
-        Long savedId = savedApplyForm.getId();
-        String generatedUrl = APPLY_FORM_BASE_URL + savedId;
+        Long savedPostingId = savedApplyForm.getId();
+        String generatedUrl = String.format(APPLY_POST_BASE_URL, savedPostingId);
         savedApplyForm.setUrl(generatedUrl);
 
         return savedApplyForm;
@@ -63,95 +38,6 @@ public class ApplyFormService {
                 request.endDate(),
                 createdDashboard
         );
-    }
-
-    @Transactional
-    public void submit(ApplyFormSubmitRequest request, long applyFormId) {
-        validatePersonalDataCollection(request);
-
-        ApplyForm applyForm = applyFormRepository.findById(applyFormId)
-                .orElseThrow(ApplyFormNotFoundException::new);
-
-        Process firstProcess = processRepository.findFirstByDashboardIdOrderBySequenceAsc(
-                        applyForm.getDashboard().getId()
-                )
-                .orElseThrow(InternalServerException::new);
-
-        Applicant applicant = applicantRepository.save(
-                new Applicant(
-                        request.applicantCreateRequest().name(),
-                        request.applicantCreateRequest().email(),
-                        request.applicantCreateRequest().phone(),
-                        firstProcess
-                )
-        );
-
-        for (AnswerCreateRequest answerCreateRequest : request.answerCreateRequest()) {
-            saveAnswerReplies(answerCreateRequest, applicant);
-        }
-    }
-
-    private void validatePersonalDataCollection(ApplyFormSubmitRequest request) {
-        if (!request.personalDataCollection()) {
-            throw new PersonalDataProcessingException();
-        }
-    }
-
-    private void saveAnswerReplies(AnswerCreateRequest answerCreateRequest, Applicant applicant) {
-        for (String reply : answerCreateRequest.replies()) {
-            Question question = questionRepository.findById(answerCreateRequest.questionId())
-                    .orElseThrow(QuestionNotFoundException::new);
-            Answer answer = new Answer(reply, question, applicant);
-            answerRepository.save(answer);
-        }
-    }
-
-    public ApplyFormResponse read(long applyFormId) {
-        ApplyForm applyForm = applyFormRepository.findById(applyFormId)
-                .orElseThrow(ApplyFormNotFoundException::new);
-
-        List<QuestionResponse> questionResponses = questionRepository.findAllByApplyFormId(applyFormId)
-                .stream()
-                .map(this::toQuestionResponse)
-                .toList();
-
-        return new ApplyFormResponse(
-                applyForm.getTitle(),
-                applyForm.getDescription(),
-                applyForm.getStartDate(),
-                applyForm.getEndDate(),
-                questionResponses
-        );
-    }
-
-    private QuestionResponse toQuestionResponse(Question question) {
-        List<Choice> choices = getChoices(question);
-        return new QuestionResponse(
-                question.getId(),
-                question.getQuestionType().name(),
-                question.getContent(),
-                question.getDescription(),
-                question.getSequence(),
-                toChoiceResponses(choices),
-                question.getRequired()
-        );
-    }
-
-    private List<Choice> getChoices(Question question) {
-        if (question.hasChoice()) {
-            return choiceRepository.findAllByQuestionId(question.getId());
-        }
-        return Collections.emptyList();
-    }
-
-    private List<ChoiceResponse> toChoiceResponses(List<Choice> choices) {
-        return choices.stream()
-                .map(this::toChoiceResponse)
-                .toList();
-    }
-
-    private ChoiceResponse toChoiceResponse(Choice choice) {
-        return new ChoiceResponse(choice.getId(), choice.getContent(), choice.getSequence());
     }
 
     public ApplyForm findById(long applyFormId) {

--- a/backend/src/main/java/com/cruru/applyform/service/facade/ApplyFormFacade.java
+++ b/backend/src/main/java/com/cruru/applyform/service/facade/ApplyFormFacade.java
@@ -1,8 +1,18 @@
 package com.cruru.applyform.service.facade;
 
+import com.cruru.answer.service.AnswerService;
+import com.cruru.applicant.controller.dto.ApplicantCreateRequest;
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.service.ApplicantService;
+import com.cruru.applyform.controller.dto.AnswerCreateRequest;
 import com.cruru.applyform.controller.dto.ApplyFormResponse;
+import com.cruru.applyform.controller.dto.ApplyFormSubmitRequest;
 import com.cruru.applyform.domain.ApplyForm;
+import com.cruru.applyform.exception.badrequest.PersonalDataCollectDisagreeException;
 import com.cruru.applyform.service.ApplyFormService;
+import com.cruru.dashboard.domain.Dashboard;
+import com.cruru.process.domain.Process;
+import com.cruru.process.service.ProcessService;
 import com.cruru.question.domain.Question;
 import com.cruru.question.service.QuestionService;
 import java.util.List;
@@ -17,10 +27,13 @@ public class ApplyFormFacade {
 
     private final QuestionService questionService;
     private final ApplyFormService applyFormService;
+    private final ProcessService processService;
+    private final ApplicantService applicantService;
+    private final AnswerService answerService;
 
-    public ApplyFormResponse findApplyFormById(long applyFormId) {
+    public ApplyFormResponse readApplyFormById(long applyFormId) {
         ApplyForm applyForm = applyFormService.findById(applyFormId);
-        List<Question> questions = questionService.findByApplyFormId(applyFormId);
+        List<Question> questions = questionService.findByApplyForm(applyForm);
 
         return new ApplyFormResponse(
                 applyForm.getTitle(),
@@ -29,5 +42,28 @@ public class ApplyFormFacade {
                 applyForm.getEndDate(),
                 questionService.toQuestionResponses(questions)
         );
+    }
+
+    @Transactional
+    public void submit(long applyFormId, ApplyFormSubmitRequest request) {
+        validatePersonalDataCollection(request);
+        ApplyForm applyForm = applyFormService.findById(applyFormId);
+        Dashboard dashboard = applyForm.getDashboard();
+        Process firstProcess = processService.findFirstProcessOnDashboard(dashboard);
+
+        ApplicantCreateRequest applicantCreateRequest = request.applicantCreateRequest();
+        Applicant applicant = applicantService.create(applicantCreateRequest, firstProcess);
+
+        List<AnswerCreateRequest> answerCreateRequests = request.answerCreateRequest();
+        for (AnswerCreateRequest answerCreateRequest : answerCreateRequests) {
+            Question targetQuestion = questionService.findById(answerCreateRequest.questionId());
+            answerService.saveAnswerReplies(answerCreateRequest, targetQuestion, applicant);
+        }
+    }
+
+    private void validatePersonalDataCollection(ApplyFormSubmitRequest request) {
+        if (!request.personalDataCollection()) {
+            throw new PersonalDataCollectDisagreeException();
+        }
     }
 }

--- a/backend/src/main/java/com/cruru/choice/controller/dto/ChoiceResponse.java
+++ b/backend/src/main/java/com/cruru/choice/controller/dto/ChoiceResponse.java
@@ -1,8 +1,11 @@
 package com.cruru.choice.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record ChoiceResponse(
         long id,
 
+        @JsonProperty("label")
         String content,
 
         int orderIndex

--- a/backend/src/main/java/com/cruru/club/controller/ClubController.java
+++ b/backend/src/main/java/com/cruru/club/controller/ClubController.java
@@ -1,7 +1,7 @@
 package com.cruru.club.controller;
 
 import com.cruru.club.controller.dto.ClubCreateRequest;
-import com.cruru.club.service.ClubService;
+import com.cruru.club.service.facade.ClubFacade;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ClubController {
 
-    private final ClubService clubService;
+    private final ClubFacade clubFacade;
 
     @PostMapping
     public ResponseEntity<Void> create(
             @RequestBody @Valid ClubCreateRequest request,
             @RequestParam(name = "memberId") Long memberId
     ) {
-        long clubId = clubService.create(request, memberId);
+        long clubId = clubFacade.create(request, memberId);
         return ResponseEntity.created(URI.create("/v1/clubs/" + clubId)).build();
     }
 }

--- a/backend/src/main/java/com/cruru/club/service/ClubService.java
+++ b/backend/src/main/java/com/cruru/club/service/ClubService.java
@@ -5,8 +5,6 @@ import com.cruru.club.domain.Club;
 import com.cruru.club.domain.repository.ClubRepository;
 import com.cruru.club.exception.ClubNotFoundException;
 import com.cruru.member.domain.Member;
-import com.cruru.member.domain.repository.MemberRepository;
-import com.cruru.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,15 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClubService {
 
     private final ClubRepository clubRepository;
-    private final MemberRepository memberRepository;
 
     @Transactional
-    public long create(ClubCreateRequest request, long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
-
-        Club club = clubRepository.save(new Club(request.name(), member));
-        return club.getId();
+    public Club create(ClubCreateRequest request, Member member) {
+        return clubRepository.save(new Club(request.name(), member));
     }
 
     public Club findById(long id) {

--- a/backend/src/main/java/com/cruru/club/service/facade/ClubFacade.java
+++ b/backend/src/main/java/com/cruru/club/service/facade/ClubFacade.java
@@ -1,0 +1,27 @@
+package com.cruru.club.service.facade;
+
+import com.cruru.club.controller.dto.ClubCreateRequest;
+import com.cruru.club.domain.Club;
+import com.cruru.club.service.ClubService;
+import com.cruru.member.domain.Member;
+import com.cruru.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ClubFacade {
+
+    private final ClubService clubService;
+    private final MemberService memberService;
+
+    @Transactional
+    public long create(ClubCreateRequest request, long memberId) {
+        Member clubOwner = memberService.findById(memberId);
+        Club createdClub = clubService.create(request, clubOwner);
+
+        return createdClub.getId();
+    }
+}

--- a/backend/src/main/java/com/cruru/dashboard/controller/DashboardController.java
+++ b/backend/src/main/java/com/cruru/dashboard/controller/DashboardController.java
@@ -1,5 +1,6 @@
 package com.cruru.dashboard.controller;
 
+import com.cruru.dashboard.controller.dto.ApplyFormUrlResponse;
 import com.cruru.dashboard.controller.dto.DashboardCreateRequest;
 import com.cruru.dashboard.controller.dto.DashboardsOfClubResponse;
 import com.cruru.dashboard.service.facade.DashboardFacade;
@@ -22,12 +23,14 @@ public class DashboardController {
     private final DashboardFacade dashboardFacade;
 
     @PostMapping
-    public ResponseEntity<Void> create(
+    public ResponseEntity<ApplyFormUrlResponse> create(
             @RequestParam(name = "clubId") Long clubId,
             @RequestBody @Valid DashboardCreateRequest request) {
 
         long dashboardId = dashboardFacade.create(clubId, request);
-        return ResponseEntity.created(URI.create("/v1/dashboards/" + dashboardId)).build();
+        ApplyFormUrlResponse applyFormUrlResponse = dashboardFacade.findFormUrlByDashboardId(dashboardId);
+        return ResponseEntity.created(URI.create("/v1/dashboards/" + dashboardId))
+                .body(applyFormUrlResponse);
     }
 
     @GetMapping

--- a/backend/src/main/java/com/cruru/dashboard/controller/dto/ApplyFormUrlResponse.java
+++ b/backend/src/main/java/com/cruru/dashboard/controller/dto/ApplyFormUrlResponse.java
@@ -1,0 +1,5 @@
+package com.cruru.dashboard.controller.dto;
+
+public record ApplyFormUrlResponse(long postId, String postUrl) {
+
+}

--- a/backend/src/main/java/com/cruru/dashboard/service/DashboardService.java
+++ b/backend/src/main/java/com/cruru/dashboard/service/DashboardService.java
@@ -5,6 +5,7 @@ import com.cruru.club.domain.repository.ClubRepository;
 import com.cruru.club.exception.ClubNotFoundException;
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.dashboard.domain.repository.DashboardRepository;
+import com.cruru.dashboard.exception.DashboardNotFoundException;
 import com.cruru.process.domain.Process;
 import com.cruru.process.domain.ProcessFactory;
 import com.cruru.process.domain.repository.ProcessRepository;
@@ -34,6 +35,11 @@ public class DashboardService {
         processRepository.saveAll(List.of(firstProcess, lastProcess));
 
         return savedDashboard;
+    }
+
+    public Dashboard findById(long id) {
+        return dashboardRepository.findById(id)
+                .orElseThrow(DashboardNotFoundException::new);
     }
 
     public List<Dashboard> findAllByClubId(long clubId) {

--- a/backend/src/main/java/com/cruru/dashboard/service/facade/DashboardFacade.java
+++ b/backend/src/main/java/com/cruru/dashboard/service/facade/DashboardFacade.java
@@ -6,6 +6,7 @@ import com.cruru.applyform.controller.dto.ApplyFormCreateRequest;
 import com.cruru.applyform.domain.ApplyForm;
 import com.cruru.applyform.service.ApplyFormService;
 import com.cruru.club.service.ClubService;
+import com.cruru.dashboard.controller.dto.ApplyFormUrlResponse;
 import com.cruru.dashboard.controller.dto.DashboardCreateRequest;
 import com.cruru.dashboard.controller.dto.DashboardPreviewResponse;
 import com.cruru.dashboard.controller.dto.DashboardsOfClubResponse;

--- a/backend/src/main/java/com/cruru/dashboard/service/facade/DashboardFacade.java
+++ b/backend/src/main/java/com/cruru/dashboard/service/facade/DashboardFacade.java
@@ -52,6 +52,12 @@ public class DashboardFacade {
         );
     }
 
+    public ApplyFormUrlResponse findFormUrlByDashboardId(long dashboardId) {
+        Dashboard dashboard = dashboardService.findById(dashboardId);
+        ApplyForm applyForm = applyFormService.findByDashboard(dashboard);
+        return new ApplyFormUrlResponse(applyForm.getId(), applyForm.getUrl());
+    }
+
     public DashboardsOfClubResponse findAllDashboardsByClubId(long clubId) {
         List<Long> dashboardIds = getDashboardIdsByClubId(clubId);
         String clubName = clubService.findById(clubId).getName();
@@ -73,7 +79,8 @@ public class DashboardFacade {
     }
 
     private DashboardPreviewResponse createDashboardPreviewResponse(Long dashboardId) {
-        ApplyForm applyForm = applyFormService.findByDashboardId(dashboardId);
+        Dashboard dashboard = dashboardService.findById(dashboardId);
+        ApplyForm applyForm = applyFormService.findByDashboard(dashboard);
         List<Applicant> allApplicants = getAllApplicantsByDashboardId(dashboardId);
         StatsResponse stats = calculateStats(allApplicants);
         return new DashboardPreviewResponse(
@@ -109,7 +116,8 @@ public class DashboardFacade {
     }
 
     private List<Applicant> getAllApplicantsByDashboardId(Long dashboardId) {
-        List<Process> processes = processService.findAllByDashboardId(dashboardId);
+        Dashboard dashboard = dashboardService.findById(dashboardId);
+        List<Process> processes = processService.findAllByDashboard(dashboard);
         return processes.stream()
                 .flatMap(process -> applicantService.findAllByProcess(process)
                         .stream())

--- a/backend/src/main/java/com/cruru/evaluation/service/EvaluationService.java
+++ b/backend/src/main/java/com/cruru/evaluation/service/EvaluationService.java
@@ -29,6 +29,10 @@ public class EvaluationService {
         return evaluationRepository.findAllByProcessAndApplicant(process, applicant);
     }
 
+    public int count(Process process, Applicant applicant) {
+        return evaluationRepository.countByApplicantAndProcess(applicant, process);
+    }
+
     @Transactional
     public void update(EvaluationUpdateRequest request, long evaluationId) {
         Evaluation evaluation = evaluationRepository.findById(evaluationId)

--- a/backend/src/main/java/com/cruru/member/controller/MemberController.java
+++ b/backend/src/main/java/com/cruru/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.cruru.member.controller;
 
 import com.cruru.member.controller.dto.MemberCreateRequest;
-import com.cruru.member.service.MemberService;
+import com.cruru.member.service.facade.MemberFacade;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
 
-    private final MemberService memberService;
+    private final MemberFacade memberFacade;
 
     @PostMapping
     public ResponseEntity<Void> create(@RequestBody @Valid MemberCreateRequest request) {
-        long memberId = memberService.create(request);
+        long memberId = memberFacade.create(request);
         return ResponseEntity.created(URI.create("/v1/members/" + memberId)).build();
     }
 }

--- a/backend/src/main/java/com/cruru/member/service/MemberService.java
+++ b/backend/src/main/java/com/cruru/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.cruru.member.service;
 import com.cruru.member.controller.dto.MemberCreateRequest;
 import com.cruru.member.domain.Member;
 import com.cruru.member.domain.repository.MemberRepository;
+import com.cruru.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,8 +16,12 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public long create(MemberCreateRequest request) {
-        Member member = memberRepository.save(new Member(request.email(), request.password(), request.phone()));
-        return member.getId();
+    public Member create(MemberCreateRequest request) {
+        return memberRepository.save(new Member(request.email(), request.password(), request.phone()));
+    }
+
+    public Member findById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/backend/src/main/java/com/cruru/member/service/facade/MemberFacade.java
+++ b/backend/src/main/java/com/cruru/member/service/facade/MemberFacade.java
@@ -1,0 +1,22 @@
+package com.cruru.member.service.facade;
+
+import com.cruru.member.controller.dto.MemberCreateRequest;
+import com.cruru.member.domain.Member;
+import com.cruru.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberFacade {
+
+    private final MemberService memberService;
+
+    @Transactional
+    public long create(MemberCreateRequest request) {
+        Member savedMember = memberService.create(request);
+        return savedMember.getId();
+    }
+}

--- a/backend/src/main/java/com/cruru/process/controller/ProcessController.java
+++ b/backend/src/main/java/com/cruru/process/controller/ProcessController.java
@@ -2,9 +2,9 @@ package com.cruru.process.controller;
 
 import com.cruru.process.controller.dto.ProcessCreateRequest;
 import com.cruru.process.controller.dto.ProcessResponse;
+import com.cruru.process.controller.dto.ProcessResponses;
 import com.cruru.process.controller.dto.ProcessUpdateRequest;
-import com.cruru.process.controller.dto.ProcessesResponse;
-import com.cruru.process.service.ProcessService;
+import com.cruru.process.service.facade.ProcessFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,11 +24,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ProcessController {
 
-    private final ProcessService processService;
+    private final ProcessFacade processFacade;
 
     @GetMapping
-    public ResponseEntity<ProcessesResponse> read(@RequestParam(name = "dashboardId") Long dashboardId) {
-        ProcessesResponse processes = processService.findByDashboardId(dashboardId);
+    public ResponseEntity<ProcessResponses> read(@RequestParam(name = "dashboardId") Long dashboardId) {
+        ProcessResponses processes = processFacade.readAllByDashboardId(dashboardId);
         return ResponseEntity.ok().body(processes);
     }
 
@@ -37,7 +37,7 @@ public class ProcessController {
             @RequestParam(name = "dashboardId") Long dashboardId,
             @RequestBody @Valid ProcessCreateRequest request
     ) {
-        processService.create(request, dashboardId);
+        processFacade.create(request, dashboardId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -46,13 +46,13 @@ public class ProcessController {
             @PathVariable Long processId,
             @RequestBody @Valid ProcessUpdateRequest request
     ) {
-        ProcessResponse response = processService.update(request, processId);
+        ProcessResponse response = processFacade.update(request, processId);
         return ResponseEntity.ok().body(response);
     }
 
     @DeleteMapping("/{processId}")
     public ResponseEntity<Void> delete(@PathVariable Long processId) {
-        processService.delete(processId);
+        processFacade.delete(processId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/cruru/process/controller/dto/ProcessResponse.java
+++ b/backend/src/main/java/com/cruru/process/controller/dto/ProcessResponse.java
@@ -1,11 +1,12 @@
 package com.cruru.process.controller.dto;
 
-import com.cruru.applicant.controller.dto.DashboardApplicantResponse;
+import com.cruru.applicant.controller.dto.ApplicantCardResponse;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 public record ProcessResponse(
-        long processId,
+        @JsonProperty("processId")
+        long id,
 
         @JsonProperty("orderIndex")
         int sequence,
@@ -15,7 +16,7 @@ public record ProcessResponse(
         String description,
 
         @JsonProperty("applicants")
-        List<DashboardApplicantResponse> dashboardApplicantResponses
+        List<ApplicantCardResponse> applicantCardResponses
 ) {
 
 }

--- a/backend/src/main/java/com/cruru/process/controller/dto/ProcessResponses.java
+++ b/backend/src/main/java/com/cruru/process/controller/dto/ProcessResponses.java
@@ -3,9 +3,14 @@ package com.cruru.process.controller.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-public record ProcessesResponse(
+public record ProcessResponses(
+
+        String postUrl,
+
         @JsonProperty("processes")
-        List<ProcessResponse> processResponses
+        List<ProcessResponse> processResponses,
+
+        String title
 ) {
 
 }

--- a/backend/src/main/java/com/cruru/process/domain/repository/ProcessRepository.java
+++ b/backend/src/main/java/com/cruru/process/domain/repository/ProcessRepository.java
@@ -13,4 +13,6 @@ public interface ProcessRepository extends JpaRepository<Process, Long> {
     long countByDashboard(Dashboard dashboard);
 
     Optional<Process> findFirstByDashboardIdOrderBySequenceAsc(long dashboardId);
+
+    List<Process> findAllByDashboard(Dashboard dashboard);
 }

--- a/backend/src/main/java/com/cruru/process/exception/badrequest/ProcessNoChangeException.java
+++ b/backend/src/main/java/com/cruru/process/exception/badrequest/ProcessNoChangeException.java
@@ -1,0 +1,12 @@
+package com.cruru.process.exception.badrequest;
+
+import com.cruru.advice.badrequest.BadRequestException;
+
+public class ProcessNoChangeException extends BadRequestException {
+
+    private static final String MESSAGE = "변경된 정보가 없습니다.";
+
+    public ProcessNoChangeException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/cruru/process/service/ProcessService.java
+++ b/backend/src/main/java/com/cruru/process/service/ProcessService.java
@@ -1,5 +1,6 @@
 package com.cruru.process.service;
 
+import com.cruru.advice.InternalServerException;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.process.controller.dto.ProcessCreateRequest;
@@ -62,6 +63,14 @@ public class ProcessService {
 
     private Process toProcess(ProcessCreateRequest request, Dashboard dashboard) {
         return new Process(request.sequence(), request.name(), request.description(), dashboard);
+    }
+
+    public Process findFirstProcessOnDashboard(Dashboard dashboard) {
+        List<Process> processes = findAllByDashboard(dashboard);
+        return processes.stream()
+                .filter(process -> process.getSequence() == PROCESS_FIRST_SEQUENCE)
+                .findFirst()
+                .orElseThrow(InternalServerException::new);
     }
 
     @Transactional

--- a/backend/src/main/java/com/cruru/process/service/ProcessService.java
+++ b/backend/src/main/java/com/cruru/process/service/ProcessService.java
@@ -1,23 +1,17 @@
 package com.cruru.process.service;
 
-import com.cruru.applicant.controller.dto.DashboardApplicantResponse;
-import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.dashboard.domain.Dashboard;
-import com.cruru.dashboard.domain.repository.DashboardRepository;
-import com.cruru.dashboard.exception.DashboardNotFoundException;
-import com.cruru.evaluation.domain.repository.EvaluationRepository;
 import com.cruru.process.controller.dto.ProcessCreateRequest;
-import com.cruru.process.controller.dto.ProcessResponse;
 import com.cruru.process.controller.dto.ProcessSimpleResponse;
 import com.cruru.process.controller.dto.ProcessUpdateRequest;
-import com.cruru.process.controller.dto.ProcessesResponse;
 import com.cruru.process.domain.Process;
 import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.process.exception.ProcessNotFoundException;
 import com.cruru.process.exception.badrequest.ProcessCountException;
 import com.cruru.process.exception.badrequest.ProcessDeleteEndsException;
 import com.cruru.process.exception.badrequest.ProcessDeleteRemainingApplicantException;
+import com.cruru.process.exception.badrequest.ProcessNoChangeException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,115 +24,73 @@ public class ProcessService {
 
     private static final int MAX_PROCESS_COUNT = 5;
     private static final int PROCESS_FIRST_SEQUENCE = 0;
+    private static final int ZERO = 0;
 
     private final ApplicantRepository applicantRepository;
     private final ProcessRepository processRepository;
-    private final DashboardRepository dashboardRepository;
-    private final EvaluationRepository evaluationRepository;
+
+    public ProcessSimpleResponse toProcessSimpleResponse(Process process) {
+        return new ProcessSimpleResponse(process.getId(), process.getName());
+    }
+
+    @Transactional
+    public void create(ProcessCreateRequest request, Dashboard dashboard) {
+        validateProcessCount(dashboard);
+        List<Process> processes = findAllByDashboard(dashboard);
+
+        rearrangeProcesses(request.sequence(), processes);
+
+        processRepository.save(toProcess(request, dashboard));
+    }
+
+    private void validateProcessCount(Dashboard dashboard) {
+        long size = processRepository.countByDashboard(dashboard);
+        if (size >= MAX_PROCESS_COUNT) {
+            throw new ProcessCountException(MAX_PROCESS_COUNT);
+        }
+    }
+
+    private void rearrangeProcesses(int newProcessSequence, List<Process> processes) {
+        processes.stream()
+                .filter(process -> process.getSequence() >= newProcessSequence)
+                .forEach(Process::increaseSequenceNumber);
+    }
+
+    public List<Process> findAllByDashboard(Dashboard dashboard) {
+        return processRepository.findAllByDashboard(dashboard);
+    }
+
+    private Process toProcess(ProcessCreateRequest request, Dashboard dashboard) {
+        return new Process(request.sequence(), request.name(), request.description(), dashboard);
+    }
+
+    @Transactional
+    public Process update(ProcessUpdateRequest request, long processId) {
+        Process process = findById(processId);
+
+        if (nothingToChange(request, process)) {
+            throw new ProcessNoChangeException();
+        }
+        process.updateName(request.name());
+        process.updateDescription(request.description());
+
+        return process;
+    }
 
     public Process findById(long processId) {
         return processRepository.findById(processId)
                 .orElseThrow(ProcessNotFoundException::new);
     }
 
-    public ProcessesResponse findByDashboardId(long dashboardId) {
-        boolean dashboardExists = dashboardRepository.existsById(dashboardId);
-        if (!dashboardExists) {
-            throw new DashboardNotFoundException();
-        }
-
-        return new ProcessesResponse(processRepository.findAllByDashboardId(dashboardId)
-                .stream()
-                .map(this::toProcessResponse)
-                .toList());
-    }
-
-    private ProcessResponse toProcessResponse(Process process) {
-        List<DashboardApplicantResponse> dashboardApplicantResponses = createDashboardApplicantResponses(process);
-
-        return new ProcessResponse(
-                process.getId(),
-                process.getSequence(),
-                process.getName(),
-                process.getDescription(),
-                dashboardApplicantResponses
-        );
-    }
-
-    private List<DashboardApplicantResponse> createDashboardApplicantResponses(Process process) {
-        return applicantRepository.findAllByProcess(process)
-                .stream()
-                .map(applicant -> toDashboardApplicantResponse(applicant, process))
-                .toList();
-    }
-
-    private DashboardApplicantResponse toDashboardApplicantResponse(Applicant applicant, Process process) {
-        int evaluationCount = evaluationRepository.countByApplicantAndProcess(applicant, process);
-        return new DashboardApplicantResponse(
-                applicant.getId(),
-                applicant.getName(),
-                applicant.getCreatedDate(),
-                applicant.isRejected(),
-                evaluationCount
-        );
-    }
-
-    public ProcessSimpleResponse toProcessSimpleResponse(Process process) {
-        return new ProcessSimpleResponse(process.getId(), process.getName());
-    }
-
-    public List<Process> findAllByDashboardId(long dashboardId) {
-        boolean dashboardExists = dashboardRepository.existsById(dashboardId);
-        if (!dashboardExists) {
-            throw new DashboardNotFoundException();
-        }
-
-        return processRepository.findAllByDashboardId(dashboardId);
-    }
-
-    @Transactional
-    public void create(ProcessCreateRequest request, long dashboardId) {
-        List<Process> allByDashboardId = processRepository.findAllByDashboardId(dashboardId);
-        validateProcessCount(allByDashboardId);
-        Dashboard dashboard = dashboardRepository.findById(dashboardId)
-                .orElseThrow(DashboardNotFoundException::new);
-
-        allByDashboardId.stream()
-                .filter(process -> process.getSequence() >= request.sequence())
-                .forEach(Process::increaseSequenceNumber);
-
-        processRepository.save(new Process(
-                        request.sequence(),
-                        request.name(),
-                        request.description(),
-                        dashboard
-                )
-        );
-    }
-
-    private void validateProcessCount(List<Process> processes) {
-        if (processes.size() == MAX_PROCESS_COUNT) {
-            throw new ProcessCountException(MAX_PROCESS_COUNT);
-        }
-    }
-
-    @Transactional
-    public ProcessResponse update(ProcessUpdateRequest request, long processId) {
-        Process process = processRepository.findById(processId)
-                .orElseThrow(ProcessNotFoundException::new);
-
-        process.updateName(request.name());
-        process.updateDescription(request.description());
-
-        return toProcessResponse(process);
+    private boolean nothingToChange(ProcessUpdateRequest request, Process process) {
+        return request.name().equals(process.getName()) && request.description().equals(process.getDescription());
     }
 
     @Transactional
     public void delete(long processId) {
-        Process process = processRepository.findById(processId)
-                .orElseThrow(ProcessNotFoundException::new);
+        Process process = findById(processId);
         validateFirstOrLastProcess(process);
-        validateExistsApplicant(process);
+        validateApplicantRemains(process);
         processRepository.deleteById(processId);
     }
 
@@ -149,9 +101,9 @@ public class ProcessService {
         }
     }
 
-    private void validateExistsApplicant(Process process) {
-        int applicantCount = (int) applicantRepository.countByProcess(process);
-        if (applicantCount > 0) {
+    private void validateApplicantRemains(Process process) {
+        long applicantCount = applicantRepository.countByProcess(process);
+        if (applicantCount > ZERO) {
             throw new ProcessDeleteRemainingApplicantException();
         }
     }

--- a/backend/src/main/java/com/cruru/process/service/facade/ProcessFacade.java
+++ b/backend/src/main/java/com/cruru/process/service/facade/ProcessFacade.java
@@ -1,0 +1,88 @@
+package com.cruru.process.service.facade;
+
+import com.cruru.applicant.controller.dto.ApplicantCardResponse;
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.service.ApplicantService;
+import com.cruru.applyform.domain.ApplyForm;
+import com.cruru.applyform.service.ApplyFormService;
+import com.cruru.dashboard.domain.Dashboard;
+import com.cruru.dashboard.service.DashboardService;
+import com.cruru.evaluation.service.EvaluationService;
+import com.cruru.process.controller.dto.ProcessCreateRequest;
+import com.cruru.process.controller.dto.ProcessResponse;
+import com.cruru.process.controller.dto.ProcessResponses;
+import com.cruru.process.controller.dto.ProcessUpdateRequest;
+import com.cruru.process.domain.Process;
+import com.cruru.process.service.ProcessService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProcessFacade {
+
+    private final ProcessService processService;
+    private final DashboardService dashboardService;
+    private final ApplicantService applicantService;
+    private final EvaluationService evaluationService;
+    private final ApplyFormService applyFormService;
+
+    @Transactional
+    public void create(ProcessCreateRequest request, long dashboardId) {
+        Dashboard dashboard = dashboardService.findById(dashboardId);
+        processService.create(request, dashboard);
+    }
+
+    public ProcessResponses readAllByDashboardId(long dashboardId) {
+        Dashboard dashboard = dashboardService.findById(dashboardId);
+        ApplyForm applyForm = applyFormService.findByDashboard(dashboard);
+        List<Process> processes = processService.findAllByDashboard(dashboard);
+        List<ProcessResponse> processResponses = toProcessResponses(processes);
+        return new ProcessResponses(applyForm.getUrl(), processResponses, applyForm.getTitle());
+    }
+
+    private List<ProcessResponse> toProcessResponses(List<Process> processes) {
+        return processes.stream()
+                .map(this::toProcessResponse)
+                .toList();
+    }
+
+    private List<ApplicantCardResponse> toApplicantCardResponses(
+            Process process, List<Applicant> applicantsOfProcess
+    ) {
+        return applicantsOfProcess.stream()
+                .map(applicant -> toApplicantCardResponse(process, applicant))
+                .toList();
+    }
+
+    private ApplicantCardResponse toApplicantCardResponse(Process process, Applicant applicant) {
+        int evaluationCount = evaluationService.count(process, applicant);
+        return applicantService.toApplicantCardResponse(applicant, evaluationCount);
+    }
+
+    @Transactional
+    public ProcessResponse update(ProcessUpdateRequest request, long processId) {
+        Process process = processService.findById(processId);
+        processService.update(request, process.getId());
+        return toProcessResponse(process);
+    }
+
+    @Transactional
+    public void delete(long processId) {
+        processService.delete(processId);
+    }
+
+    private ProcessResponse toProcessResponse(Process process) {
+        List<Applicant> applicantsOfProcess = applicantService.findAllByProcess(process);
+        List<ApplicantCardResponse> applicantCardResponses = toApplicantCardResponses(process, applicantsOfProcess);
+        return new ProcessResponse(process.getId(),
+                process.getSequence(),
+                process.getName(),
+                process.getDescription(),
+                applicantCardResponses
+        );
+    }
+}

--- a/backend/src/main/java/com/cruru/question/controller/dto/QuestionResponse.java
+++ b/backend/src/main/java/com/cruru/question/controller/dto/QuestionResponse.java
@@ -9,6 +9,7 @@ public record QuestionResponse(
 
         String type,
 
+        @JsonProperty("label")
         String content,
 
         String description,

--- a/backend/src/main/java/com/cruru/question/domain/repository/QuestionRepository.java
+++ b/backend/src/main/java/com/cruru/question/domain/repository/QuestionRepository.java
@@ -1,10 +1,11 @@
 package com.cruru.question.domain.repository;
 
+import com.cruru.applyform.domain.ApplyForm;
 import com.cruru.question.domain.Question;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-    List<Question> findAllByApplyFormId(long applyFormId);
+    List<Question> findAllByApplyForm(ApplyForm applyForm);
 }

--- a/backend/src/main/java/com/cruru/question/service/QuestionService.java
+++ b/backend/src/main/java/com/cruru/question/service/QuestionService.java
@@ -9,6 +9,7 @@ import com.cruru.question.controller.dto.QuestionResponse;
 import com.cruru.question.domain.Question;
 import com.cruru.question.domain.QuestionType;
 import com.cruru.question.domain.repository.QuestionRepository;
+import com.cruru.question.exception.QuestionNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,9 @@ public class QuestionService {
 
     @Transactional
     public void createAll(List<QuestionCreateRequest> requests, ApplyForm applyForm) {
-        requests.forEach(questionCreateRequest -> create(questionCreateRequest, applyForm));
+        for (QuestionCreateRequest questionCreateRequest : requests) {
+            create(questionCreateRequest, applyForm);
+        }
     }
 
     @Transactional
@@ -51,8 +54,13 @@ public class QuestionService {
         );
     }
 
-    public List<Question> findByApplyFormId(Long applyFormId) {
-        return questionRepository.findAllByApplyFormId(applyFormId);
+    public Question findById(long id) {
+        return questionRepository.findById(id)
+                .orElseThrow(QuestionNotFoundException::new);
+    }
+
+    public List<Question> findByApplyForm(ApplyForm applyForm) {
+        return questionRepository.findAllByApplyForm(applyForm);
     }
 
     public List<QuestionResponse> toQuestionResponses(List<Question> questions) {

--- a/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
+++ b/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.cruru.applicant.controller.dto.ApplicantCreateRequest;
 import com.cruru.applicant.controller.dto.ApplicantMoveRequest;
 import com.cruru.applicant.controller.dto.ApplicantUpdateRequest;
 import com.cruru.applicant.domain.Applicant;
@@ -44,6 +45,29 @@ class ApplicantServiceTest extends ServiceTest {
     @Autowired
     private EntityManager entityManager;
 
+    @DisplayName("지원자를 정상적으로 저장한다.")
+    @Test
+    void create() {
+        // given
+        Process firstProcess = processRepository.save(ProcessFixture.createFirstProcess());
+        String name = "도비";
+        String email = "kimdobby@email.com";
+        String phone = "01052525252";
+        ApplicantCreateRequest createRequest = new ApplicantCreateRequest(name, email, phone);
+
+        // when
+        Applicant createdApplicant = applicantService.create(createRequest, firstProcess);
+
+        // then
+        Applicant actualApplicant = applicantRepository.findById(createdApplicant.getId()).get();
+        assertAll(() -> {
+            assertThat(actualApplicant.getName()).isEqualTo(name);
+            assertThat(actualApplicant.getEmail()).isEqualTo(email);
+            assertThat(actualApplicant.getPhone()).isEqualTo(phone);
+        });
+    }
+
+
     @DisplayName("프로세스 내의 모든 지원자를 조회한다.")
     @Test
     void findAllByProcess() {
@@ -68,7 +92,8 @@ class ApplicantServiceTest extends ServiceTest {
         long invalidId = -1L;
 
         // when&then
-        assertThatThrownBy(() -> applicantService.findById(invalidId)).isInstanceOf(ApplicantNotFoundException.class);
+        assertThatThrownBy(() -> applicantService.findById(invalidId))
+                .isInstanceOf(ApplicantNotFoundException.class);
     }
 
     @DisplayName("지원자의 이름, 이메일, 전화번호 변경 요청시, 정보를 업데이트한다")
@@ -106,9 +131,8 @@ class ApplicantServiceTest extends ServiceTest {
         Long applicantId = applicant.getId();
 
         // when & then
-        assertThatThrownBy(
-                () -> applicantService.updateApplicantInformation(applicantId, noChangeRequest)
-        ).isInstanceOf(ApplicantNoChangeException.class);
+        assertThatThrownBy(() -> applicantService.updateApplicantInformation(applicantId, noChangeRequest))
+                .isInstanceOf(ApplicantNoChangeException.class);
     }
 
     @DisplayName("여러 건의 지원서를 요청된 프로세스로 일괄 변경한다.")
@@ -167,6 +191,7 @@ class ApplicantServiceTest extends ServiceTest {
 
         // when&then
         Long applicantId = rejectedApplicant.getId();
-        assertThatThrownBy(() -> applicantService.reject(applicantId)).isInstanceOf(ApplicantRejectException.class);
+        assertThatThrownBy(() -> applicantService.reject(applicantId))
+                .isInstanceOf(ApplicantRejectException.class);
     }
 }

--- a/backend/src/test/java/com/cruru/applyform/service/facade/ApplyFormFacadeTest.java
+++ b/backend/src/test/java/com/cruru/applyform/service/facade/ApplyFormFacadeTest.java
@@ -1,0 +1,140 @@
+package com.cruru.applyform.service.facade;
+
+import static com.cruru.util.fixture.ApplyFormFixture.createBackendApplyForm;
+import static com.cruru.util.fixture.DashboardFixture.createBackendDashboard;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.cruru.advice.InternalServerException;
+import com.cruru.answer.domain.repository.AnswerRepository;
+import com.cruru.applicant.controller.dto.ApplicantCreateRequest;
+import com.cruru.applicant.domain.repository.ApplicantRepository;
+import com.cruru.applyform.controller.dto.AnswerCreateRequest;
+import com.cruru.applyform.controller.dto.ApplyFormSubmitRequest;
+import com.cruru.applyform.domain.ApplyForm;
+import com.cruru.applyform.domain.repository.ApplyFormRepository;
+import com.cruru.applyform.exception.ApplyFormNotFoundException;
+import com.cruru.applyform.exception.badrequest.PersonalDataCollectDisagreeException;
+import com.cruru.dashboard.domain.Dashboard;
+import com.cruru.dashboard.domain.repository.DashboardRepository;
+import com.cruru.process.domain.Process;
+import com.cruru.process.domain.repository.ProcessRepository;
+import com.cruru.question.domain.Question;
+import com.cruru.question.domain.repository.QuestionRepository;
+import com.cruru.util.ServiceTest;
+import com.cruru.util.fixture.ApplyFormFixture;
+import com.cruru.util.fixture.DashboardFixture;
+import com.cruru.util.fixture.ProcessFixture;
+import com.cruru.util.fixture.QuestionFixture;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("지원서폼 파사드 서비스 테스트")
+class ApplyFormFacadeTest extends ServiceTest {
+
+    @Autowired
+    private DashboardRepository dashboardRepository;
+
+    @Autowired
+    private ProcessRepository processRepository;
+
+    @Autowired
+    private ApplyFormRepository applyFormRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private AnswerRepository answerRepository;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
+
+    @Autowired
+    private ApplyFormFacade applyFormFacade;
+
+    private Process firstProcess;
+    private Process finalProcess;
+    private ApplyForm applyForm;
+    private List<AnswerCreateRequest> answerCreateRequests;
+    private ApplyFormSubmitRequest applyFormSubmitrequest;
+    private ApplicantCreateRequest applicantCreateRequest;
+
+    @BeforeEach
+    void setUp() {
+        Dashboard dashboard = dashboardRepository.save(DashboardFixture.createBackendDashboard(null));
+        firstProcess = processRepository.save(ProcessFixture.createFirstProcess(dashboard));
+        finalProcess = processRepository.save(ProcessFixture.createFinalProcess(dashboard));
+        applyForm = applyFormRepository.save(ApplyFormFixture.createBackendApplyForm(dashboard));
+        Question question1 = questionRepository.save(QuestionFixture.createLongAnswerQuestion(applyForm));
+        Question question2 = questionRepository.save(QuestionFixture.createShortAnswerQuestion(applyForm));
+
+        answerCreateRequests = List.of(
+                new AnswerCreateRequest(question1.getId(), List.of("안녕하세요, 첫 번째 답변입니다")),
+                new AnswerCreateRequest(question2.getId(), List.of("온라인"))
+        );
+
+        applicantCreateRequest = new ApplicantCreateRequest(
+                "초코칩",
+                "dev.chocochip@gmail.com",
+                "01000000000"
+        );
+
+        applyFormSubmitrequest = new ApplyFormSubmitRequest(applicantCreateRequest, answerCreateRequests, true);
+    }
+
+    @DisplayName("지원서 폼 제출에 성공한다.")
+    @Test
+    void submit() {
+        // given&when
+        applyFormFacade.submit(applyForm.getId(), applyFormSubmitrequest);
+
+        // then
+        assertAll(() -> {
+            assertThat(answerRepository.findAll()).hasSize(answerCreateRequests.size());
+            assertThat(applicantRepository.countByProcess(firstProcess)).isEqualTo(1);
+            assertThat(applicantRepository.countByProcess(finalProcess)).isZero();
+        });
+    }
+
+    @DisplayName("지원서 폼 제출 시, 대시보드에 프로세스가 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void submit_dashboardWithNoProcess() {
+        // given
+        Dashboard emptyProcessDashboard = dashboardRepository.save(createBackendDashboard(null));
+        ApplyForm emptyProcessApplyForm = applyFormRepository.save(createBackendApplyForm(emptyProcessDashboard));
+
+        // when&then
+        Long emptyProcessApplyFormId = emptyProcessApplyForm.getId();
+        assertThatThrownBy(() -> applyFormFacade.submit(emptyProcessApplyFormId, applyFormSubmitrequest))
+                .isInstanceOf(InternalServerException.class);
+    }
+
+    @DisplayName("지원서 폼 제출 시, 개인정보수집에 동의하지 않은 요청은 예외가 발생한다.")
+    @Test
+    void submit_rejectPersonalDataCollection() {
+        // given
+        ApplyFormSubmitRequest notAgreedRequest = new ApplyFormSubmitRequest(
+                applicantCreateRequest,
+                answerCreateRequests,
+                false
+        );
+
+        // when&then
+        Long applyFormId = applyForm.getId();
+        assertThatThrownBy(() -> applyFormFacade.submit(applyFormId, notAgreedRequest))
+                .isInstanceOf(PersonalDataCollectDisagreeException.class);
+    }
+
+    @DisplayName("지원서 폼 제출 시, 지원서 폼이 존재하지 않을 경우 예외가 발생한다.")
+    @Test
+    void submit_invalidApplyForm() {
+        // given&when&then
+        assertThatThrownBy(() -> applyFormFacade.submit(-1, applyFormSubmitrequest))
+                .isInstanceOf(ApplyFormNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/cruru/club/service/facade/ClubFacadeTest.java
+++ b/backend/src/test/java/com/cruru/club/service/facade/ClubFacadeTest.java
@@ -1,0 +1,49 @@
+package com.cruru.club.service.facade;
+
+import static com.cruru.util.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.cruru.club.controller.dto.ClubCreateRequest;
+import com.cruru.club.domain.Club;
+import com.cruru.member.domain.Member;
+import com.cruru.member.domain.repository.MemberRepository;
+import com.cruru.util.ServiceTest;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("동아리 파사드 서비스 테스트")
+class ClubFacadeTest extends ServiceTest {
+
+    @Autowired
+    private ClubFacade clubFacade;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @DisplayName("회원가입 되어있는 회원이 새로운 동아리를 생성한다.")
+    @Test
+    void create() {
+        // given
+        Member member = memberRepository.save(createMember());
+        ClubCreateRequest request = new ClubCreateRequest("연합동아리");
+
+        // when
+        long clubId = clubFacade.create(request, member.getId());
+
+        // then
+        Club actual = entityManager.createQuery(
+                        "SELECT c FROM Club c JOIN FETCH c.member WHERE c.id = :id", Club.class)
+                .setParameter("id", clubId)
+                .getSingleResult();
+        assertAll(() -> {
+            assertThat(actual.getMember()).isEqualTo(member);
+            assertThat(actual.getName()).isEqualTo(request.name());
+        });
+    }
+}

--- a/backend/src/test/java/com/cruru/dashboard/service/facade/DashboardFacadeTest.java
+++ b/backend/src/test/java/com/cruru/dashboard/service/facade/DashboardFacadeTest.java
@@ -10,6 +10,7 @@ import com.cruru.applyform.domain.repository.ApplyFormRepository;
 import com.cruru.choice.controller.dto.ChoiceCreateRequest;
 import com.cruru.club.domain.Club;
 import com.cruru.club.domain.repository.ClubRepository;
+import com.cruru.dashboard.controller.dto.ApplyFormUrlResponse;
 import com.cruru.dashboard.controller.dto.DashboardCreateRequest;
 import com.cruru.dashboard.controller.dto.DashboardPreviewResponse;
 import com.cruru.dashboard.controller.dto.DashboardsOfClubResponse;
@@ -84,6 +85,23 @@ class DashboardFacadeTest extends ServiceTest {
 
         // then
         assertThat(dashboardRepository.findById(savedDashboardId)).isPresent();
+    }
+
+    @DisplayName("대시보드로 공고 URL을 찾는다.")
+    @Test
+    void findFormUrlByDashboardId() {
+        // given
+        Dashboard dashboard = dashboardRepository.save(new Dashboard(club));
+        ApplyForm applyForm = applyFormRepository.save(ApplyFormFixture.createBackendApplyForm(dashboard));
+
+        // when
+        ApplyFormUrlResponse applyFormUrlResponse = dashboardFacade.findFormUrlByDashboardId(dashboard.getId());
+
+        // then
+        assertAll(() -> {
+            assertThat(applyFormUrlResponse.postId()).isEqualTo(applyForm.getId());
+            assertThat(applyFormUrlResponse.postUrl()).isEqualTo(applyForm.getUrl());
+        });
     }
 
     @DisplayName("다건의 대시보드 정보를 조회한다.")

--- a/backend/src/test/java/com/cruru/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/cruru/member/service/MemberServiceTest.java
@@ -2,11 +2,13 @@ package com.cruru.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.cruru.member.controller.dto.MemberCreateRequest;
 import com.cruru.member.domain.Member;
 import com.cruru.member.domain.repository.MemberRepository;
 import com.cruru.util.ServiceTest;
+import com.cruru.util.fixture.MemberFixture;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,14 +33,31 @@ class MemberServiceTest extends ServiceTest {
         MemberCreateRequest request = new MemberCreateRequest(email, password, phone);
 
         // when
-        long memberId = memberService.create(request);
+        Member member = memberService.create(request);
 
         // then
-        Optional<Member> member = memberRepository.findById(memberId);
-        assertAll(
-                () -> assertThat(member).isPresent(),
-                () -> assertThat(member.get().getEmail()).isEqualTo(email),
-                () -> assertThat(member.get().getPhone()).isEqualTo(phone)
-        );
+        Optional<Member> actualMember = memberRepository.findById(member.getId());
+        assertAll(() -> {
+            assertThat(actualMember).isPresent();
+            Member presentMember = actualMember.get();
+            assertThat(presentMember.getEmail()).isEqualTo(email);
+            assertThat(presentMember.getPhone()).isEqualTo(phone);
+        });
+    }
+
+    @DisplayName("회원을 ID로 조회한다.")
+    @Test
+    void findById() {
+        // given
+        Member savedMember = memberRepository.save(MemberFixture.createMember());
+
+        // when&then
+        assertAll(() -> {
+            assertDoesNotThrow(() -> memberService.findById(savedMember.getId()));
+            Member actualMember = memberService.findById(savedMember.getId());
+            assertThat(actualMember.getEmail()).isEqualTo(savedMember.getEmail());
+            assertThat(actualMember.getPhone()).isEqualTo(savedMember.getPhone());
+            assertThat(actualMember.getPassword()).isEqualTo(savedMember.getPassword());
+        });
     }
 }

--- a/backend/src/test/java/com/cruru/member/service/facade/MemberFacadeTest.java
+++ b/backend/src/test/java/com/cruru/member/service/facade/MemberFacadeTest.java
@@ -1,0 +1,45 @@
+package com.cruru.member.service.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.cruru.member.controller.dto.MemberCreateRequest;
+import com.cruru.member.domain.Member;
+import com.cruru.member.domain.repository.MemberRepository;
+import com.cruru.util.ServiceTest;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("회원 파사드 서비스 테스트")
+class MemberFacadeTest extends ServiceTest {
+
+    @Autowired
+    private MemberFacade memberFacade;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("사용자를 생성하면 ID를 반환한다.")
+    @Test
+    void create() {
+        // given
+        String email = "mail@mail.com";
+        String password = "qwer1234";
+        String phone = "01012341234";
+        MemberCreateRequest request = new MemberCreateRequest(email, password, phone);
+
+        // when
+        long memberId = memberFacade.create(request);
+
+        // then
+        Optional<Member> member = memberRepository.findById(memberId);
+        assertAll(() -> {
+            assertThat(member).isPresent();
+            Member presentMemeber = member.get();
+            assertThat(presentMemeber.getEmail()).isEqualTo(email);
+            assertThat(presentMemeber.getPhone()).isEqualTo(phone);
+        });
+    }
+}

--- a/backend/src/test/java/com/cruru/process/controller/ProcessControllerTest.java
+++ b/backend/src/test/java/com/cruru/process/controller/ProcessControllerTest.java
@@ -1,9 +1,9 @@
 package com.cruru.process.controller;
 
-import static com.cruru.util.fixture.DashboardFixture.createBackendDashboard;
 import static com.cruru.util.fixture.ProcessFixture.createFirstProcess;
 import static com.cruru.util.fixture.ProcessFixture.createInterviewProcess;
 
+import com.cruru.applyform.domain.repository.ApplyFormRepository;
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.dashboard.domain.repository.DashboardRepository;
 import com.cruru.process.controller.dto.ProcessCreateRequest;
@@ -11,6 +11,8 @@ import com.cruru.process.controller.dto.ProcessUpdateRequest;
 import com.cruru.process.domain.Process;
 import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.util.ControllerTest;
+import com.cruru.util.fixture.ApplyFormFixture;
+import com.cruru.util.fixture.DashboardFixture;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,13 +27,17 @@ class ProcessControllerTest extends ControllerTest {
     private DashboardRepository dashboardRepository;
 
     @Autowired
+    private ApplyFormRepository applyFormRepository;
+
+    @Autowired
     private ProcessRepository processRepository;
 
     private Dashboard dashboard;
 
     @BeforeEach
     void setUp() {
-        dashboard = dashboardRepository.save(createBackendDashboard());
+        dashboard = dashboardRepository.save(DashboardFixture.createBackendDashboard());
+        applyFormRepository.save(ApplyFormFixture.createBackendApplyForm(dashboard));
     }
 
     @DisplayName("프로세스 조회 성공 시, 200을 응답한다.")

--- a/backend/src/test/java/com/cruru/process/service/ProcessServiceTest.java
+++ b/backend/src/test/java/com/cruru/process/service/ProcessServiceTest.java
@@ -85,6 +85,22 @@ class ProcessServiceTest extends ServiceTest {
                 .isInstanceOf(ProcessCountException.class);
     }
 
+    @DisplayName("대시보드에 존재하는 첫 번째 프로세스를 조회한다.")
+    @Test
+    void findFirstProcessOnDashboard() {
+        // given
+        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
+        Process firstProcess = processRepository.save(createFirstProcess(dashboard));
+        processRepository.save(createInterviewProcess(dashboard));
+        processRepository.save(createFinalProcess(dashboard));
+
+        // when
+        Process actualFirstProcess = processService.findFirstProcessOnDashboard(dashboard);
+
+        // then
+        assertThat(actualFirstProcess).isEqualTo(firstProcess);
+    }
+
     @DisplayName("기존 정보에서 변경점이 있는 변경 요청시, 프로세스 정보를 변경한다.")
     @Test
     void update() {
@@ -121,7 +137,6 @@ class ProcessServiceTest extends ServiceTest {
         assertThatThrownBy(() -> processService.update(processUpdateRequest, processId))
                 .isInstanceOf(ProcessNoChangeException.class);
     }
-
 
     @DisplayName("프로세스를 삭제한다.")
     @Test

--- a/backend/src/test/java/com/cruru/process/service/ProcessServiceTest.java
+++ b/backend/src/test/java/com/cruru/process/service/ProcessServiceTest.java
@@ -9,23 +9,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.dashboard.domain.repository.DashboardRepository;
-import com.cruru.dashboard.exception.DashboardNotFoundException;
-import com.cruru.evaluation.domain.Evaluation;
 import com.cruru.evaluation.domain.repository.EvaluationRepository;
 import com.cruru.process.controller.dto.ProcessCreateRequest;
-import com.cruru.process.controller.dto.ProcessResponse;
 import com.cruru.process.controller.dto.ProcessUpdateRequest;
-import com.cruru.process.controller.dto.ProcessesResponse;
 import com.cruru.process.domain.Process;
 import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.process.exception.badrequest.ProcessCountException;
 import com.cruru.process.exception.badrequest.ProcessDeleteEndsException;
 import com.cruru.process.exception.badrequest.ProcessDeleteRemainingApplicantException;
+import com.cruru.process.exception.badrequest.ProcessNoChangeException;
 import com.cruru.util.ServiceTest;
+import com.cruru.util.fixture.ProcessFixture;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -50,41 +47,6 @@ class ProcessServiceTest extends ServiceTest {
     @Autowired
     private EvaluationRepository evaluationRepository;
 
-    @DisplayName("ID에 해당하는 대시보드의 프로세스 목록과 지원자 정보를 조회한다.")
-    @Test
-    void findByDashboardId() {
-        // given
-        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
-        Process process = processRepository.save(createFirstProcess(dashboard));
-        Applicant applicant = applicantRepository.save(createPendingApplicantDobby(process));
-        evaluationRepository.save(new Evaluation(5, "하드 스킬과 소프트 스킬이 출중함.", process, applicant));
-
-        // when
-        ProcessesResponse byDashboardId = processService.findByDashboardId(dashboard.getId());
-
-        // then
-        ProcessResponse firstProcessResponse = byDashboardId.processResponses().get(0);
-        assertAll(
-                () -> assertThat(byDashboardId.processResponses()).hasSize(1),
-                () -> assertThat(firstProcessResponse.processId()).isEqualTo(process.getId()),
-                () -> assertThat(firstProcessResponse.dashboardApplicantResponses().get(0).applicantId()).isEqualTo(
-                        applicant.getId()),
-                () -> assertThat(firstProcessResponse.dashboardApplicantResponses().get(0).evaluationCount()).isEqualTo(
-                        1)
-        );
-    }
-
-    @DisplayName("대시보드가 존재하지 않는 경우, 예외가 발생한다.")
-    @Test
-    void invalidDashboardId() {
-        // given
-        long invalidId = 0;
-
-        // when&then
-        assertThatThrownBy(() -> processService.findByDashboardId(invalidId))
-                .isInstanceOf(DashboardNotFoundException.class);
-    }
-
     @DisplayName("새로운 프로세스를 생성한다.")
     @Test
     void create() {
@@ -92,10 +54,10 @@ class ProcessServiceTest extends ServiceTest {
         Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
         processRepository.save(createFirstProcess(dashboard));
         processRepository.save(createFinalProcess(dashboard));
-        ProcessCreateRequest processCreateRequest = new ProcessCreateRequest("1차 면접", "화상 면접", 1);
+        ProcessCreateRequest processCreateRequest = new ProcessCreateRequest("새로운 프로세스", "원래 있던 2개의 프로세스 사이에 생겼다.", 1);
 
         // when
-        processService.create(processCreateRequest, dashboard.getId());
+        processService.create(processCreateRequest, dashboard);
 
         // then
         List<Process> allByDashboardId = processRepository.findAllByDashboardId(dashboard.getId())
@@ -103,8 +65,11 @@ class ProcessServiceTest extends ServiceTest {
                 .sorted(Comparator.comparingInt(Process::getSequence))
                 .toList();
 
-        assertThat(allByDashboardId).hasSize(3);
-        assertThat(allByDashboardId.get(1).getName()).isEqualTo("1차 면접");
+        String actualName = allByDashboardId.get(1).getName();
+        assertAll(() -> {
+            assertThat(allByDashboardId).hasSize(3);
+            assertThat(actualName).isEqualTo("새로운 프로세스");
+        });
     }
 
     @DisplayName("프로세스 최대 개수를 초과하면, 예외가 발생한다.")
@@ -112,23 +77,15 @@ class ProcessServiceTest extends ServiceTest {
     void createOverProcessMaxCount() {
         // given
         Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
-        processRepository.saveAll(
-                List.of(
-                        new Process(0, "서류", "서류", dashboard),
-                        new Process(1, "코딩 테스트", "온라인", dashboard),
-                        new Process(2, "CS 테스트", "온라인", dashboard),
-                        new Process(3, "1차 면접", "화상 면접", dashboard),
-                        new Process(4, "최종 면접", "대면 면접", dashboard)
-                )
-        );
+        processRepository.saveAll(ProcessFixture.maxSizeOf(dashboard));
         ProcessCreateRequest processCreateRequest = new ProcessCreateRequest("2차 면접", "화상 면접", 1);
 
         // when&then
-        assertThatThrownBy(() -> processService.create(processCreateRequest, dashboard.getId()))
+        assertThatThrownBy(() -> processService.create(processCreateRequest, dashboard))
                 .isInstanceOf(ProcessCountException.class);
     }
 
-    @DisplayName("프로세스 정보를 변경한다.")
+    @DisplayName("기존 정보에서 변경점이 있는 변경 요청시, 프로세스 정보를 변경한다.")
     @Test
     void update() {
         // given
@@ -138,14 +95,33 @@ class ProcessServiceTest extends ServiceTest {
 
         // when
         Long processId = process.getId();
-        ProcessResponse actualProcessResponse = processService.update(processUpdateRequest, processId);
+        processService.update(processUpdateRequest, processId);
 
         // then
+        Process actualProcess = processRepository.findById(processId).get();
         assertAll(() -> {
-            assertThat(actualProcessResponse.name()).isEqualTo(processUpdateRequest.name());
-            assertThat(actualProcessResponse.description()).isEqualTo(processUpdateRequest.description());
+            assertThat(actualProcess.getName()).isEqualTo(processUpdateRequest.name());
+            assertThat(actualProcess.getDescription()).isEqualTo(processUpdateRequest.description());
         });
     }
+
+    @DisplayName("기존 정보에서 변경점이 없는 요청시, 예외가 발생한다.")
+    @Test
+    void update_ThrowException() {
+        // given
+        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
+        Process process = processRepository.save(createFirstProcess(dashboard));
+        String notChangedName = process.getName();
+        String notChangedDescription = process.getDescription();
+        ProcessUpdateRequest processUpdateRequest = new ProcessUpdateRequest(notChangedName, notChangedDescription);
+
+        Long processId = process.getId();
+
+        // when & then
+        assertThatThrownBy(() -> processService.update(processUpdateRequest, processId))
+                .isInstanceOf(ProcessNoChangeException.class);
+    }
+
 
     @DisplayName("프로세스를 삭제한다.")
     @Test
@@ -163,48 +139,31 @@ class ProcessServiceTest extends ServiceTest {
 
     @DisplayName("첫번째 프로세스 혹은 마지막 프로세스를 삭제하면 예외가 발생한다.")
     @Test
-    void deleteFirstOrLastProcess() {
+    void delete_FirstOrLastProcess_ThrowsException() {
         // given
         Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
         Process firstProcess = processRepository.save(createFirstProcess(dashboard));
         Process finalProcess = processRepository.save(createFinalProcess(dashboard));
 
-        // when&then
-        assertAll(
-                () -> assertThatThrownBy(() -> processService.delete(firstProcess.getId()))
-                        .isInstanceOf(ProcessDeleteEndsException.class),
-                () -> assertThatThrownBy(() -> processService.delete(finalProcess.getId()))
-                        .isInstanceOf(ProcessDeleteEndsException.class)
-        );
+        // when & then
+        Long firstProcessId = firstProcess.getId();
+        Long finalProcessId = finalProcess.getId();
+        assertAll(() -> {
+            assertThatThrownBy(() -> processService.delete(firstProcessId)).isInstanceOf(ProcessDeleteEndsException.class);
+            assertThatThrownBy(() -> processService.delete(finalProcessId)).isInstanceOf(ProcessDeleteEndsException.class);
+        });
     }
 
     @DisplayName("삭제하려는 프로세스에 해당되는 지원자가 있을 경우 예외가 발생한다.")
     @Test
-    void deleteExistsApplicantProcess() {
+    void delete_ApplicantRemainedProcess_ThrowsException() {
         // given
         Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
         Process process = processRepository.save(createInterviewProcess(dashboard));
         applicantRepository.save(createPendingApplicantDobby(process));
 
         // when&then
-        assertThatThrownBy(() -> processService.delete(process.getId()))
-                .isInstanceOf(ProcessDeleteRemainingApplicantException.class);
-    }
-
-    @DisplayName("대시보드 ID로 존재하는 모든 프로세스를 조회한다.")
-    @Test
-    void findAllByDashboardId() {
-        // given
-        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
-        List<Process> expectedProcesses = processRepository.saveAll(List.of(
-                createFirstProcess(dashboard),
-                createFinalProcess(dashboard)
-        ));
-
-        // when
-        List<Process> actualProcesses = processService.findAllByDashboardId(dashboard.getId());
-
-        // then
-        assertThat(actualProcesses).containsExactlyInAnyOrderElementsOf(expectedProcesses);
+        Long processId = process.getId();
+        assertThatThrownBy(() -> processService.delete(processId)).isInstanceOf(ProcessDeleteRemainingApplicantException.class);
     }
 }

--- a/backend/src/test/java/com/cruru/process/service/facade/ProcessFacadeTest.java
+++ b/backend/src/test/java/com/cruru/process/service/facade/ProcessFacadeTest.java
@@ -1,0 +1,137 @@
+package com.cruru.process.service.facade;
+
+import static com.cruru.util.fixture.DashboardFixture.createBackendDashboard;
+import static com.cruru.util.fixture.ProcessFixture.createFirstProcess;
+import static com.cruru.util.fixture.ProcessFixture.createInterviewProcess;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.domain.repository.ApplicantRepository;
+import com.cruru.applyform.domain.repository.ApplyFormRepository;
+import com.cruru.dashboard.domain.Dashboard;
+import com.cruru.dashboard.domain.repository.DashboardRepository;
+import com.cruru.evaluation.domain.repository.EvaluationRepository;
+import com.cruru.process.controller.dto.ProcessCreateRequest;
+import com.cruru.process.controller.dto.ProcessResponse;
+import com.cruru.process.controller.dto.ProcessResponses;
+import com.cruru.process.controller.dto.ProcessUpdateRequest;
+import com.cruru.process.domain.Process;
+import com.cruru.process.domain.repository.ProcessRepository;
+import com.cruru.util.ServiceTest;
+import com.cruru.util.fixture.ApplicantFixture;
+import com.cruru.util.fixture.ApplyFormFixture;
+import com.cruru.util.fixture.DashboardFixture;
+import com.cruru.util.fixture.EvaluationFixture;
+import com.cruru.util.fixture.ProcessFixture;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("프로세스 파사드 서비스 테스트")
+class ProcessFacadeTest extends ServiceTest {
+
+    @Autowired
+    private ProcessFacade processFacade;
+
+    @Autowired
+    private DashboardRepository dashboardRepository;
+
+    @Autowired
+    private ApplyFormRepository applyFormRepository;
+
+    @Autowired
+    private ProcessRepository processRepository;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
+
+    @Autowired
+    private EvaluationRepository evaluationRepository;
+
+    @DisplayName("새로운 프로세스를 생성한다.")
+    @Test
+    void create() {
+        // given
+        Dashboard dashboard = dashboardRepository.save(DashboardFixture.createBackendDashboard());
+        processRepository.save(ProcessFixture.createFirstProcess(dashboard));
+        processRepository.save(ProcessFixture.createFinalProcess(dashboard));
+        ProcessCreateRequest processCreateRequest = new ProcessCreateRequest("새로운 프로세스", "기존 2개의 프로세스 사이에 생성.", 1);
+
+        // when
+        processFacade.create(processCreateRequest, dashboard.getId());
+
+        // then
+        List<Process> allByDashboardId = processRepository.findAllByDashboardId(dashboard.getId())
+                .stream()
+                .sorted(Comparator.comparingInt(Process::getSequence))
+                .toList();
+
+        String newProcessName = allByDashboardId.get(1).getName();
+        assertAll(() -> {
+            assertThat(allByDashboardId).hasSize(3);
+            assertThat(newProcessName).isEqualTo("새로운 프로세스");
+        });
+    }
+
+    @DisplayName("ID에 해당하는 대시보드의 프로세스 목록과 지원자 정보를 조회한다.")
+    @Test
+    void readAllByDashboardId() {
+        // given
+        Dashboard dashboard = dashboardRepository.save(DashboardFixture.createBackendDashboard());
+        applyFormRepository.save(ApplyFormFixture.createBackendApplyForm(dashboard));
+        Process process = processRepository.save(ProcessFixture.createFirstProcess(dashboard));
+        Applicant applicant = applicantRepository.save(ApplicantFixture.createPendingApplicantDobby(process));
+        evaluationRepository.save(EvaluationFixture.createEvaluationExcellent(process, applicant));
+
+        // when
+        ProcessResponses processResponses = processFacade.readAllByDashboardId(dashboard.getId());
+
+        // then
+        ProcessResponse firstProcessResponse = processResponses.processResponses().get(0);
+        long processId = firstProcessResponse.id();
+        long applicantCardId = firstProcessResponse.applicantCardResponses().get(0).id();
+        int applicantEvaluationCount = firstProcessResponse.applicantCardResponses().get(0).evaluationCount();
+        assertAll(() -> {
+            assertThat(processResponses.processResponses()).hasSize(1);
+            assertThat(processId).isEqualTo(process.getId());
+            assertThat(applicantCardId).isEqualTo(applicant.getId());
+            assertThat(applicantEvaluationCount).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("프로세스 정보를 변경한다.")
+    @Test
+    void update() {
+        // given
+        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
+        Process process = processRepository.save(createFirstProcess(dashboard));
+        ProcessUpdateRequest processUpdateRequest = new ProcessUpdateRequest("면접 수정", "수정된 설명");
+
+        // when
+        Long processId = process.getId();
+        ProcessResponse actualProcessResponse = processFacade.update(processUpdateRequest, processId);
+
+        // then
+        assertAll(() -> {
+            assertThat(actualProcessResponse.name()).isEqualTo(processUpdateRequest.name());
+            assertThat(actualProcessResponse.description()).isEqualTo(processUpdateRequest.description());
+        });
+    }
+
+    @DisplayName("프로세스를 삭제한다.")
+    @Test
+    void delete() {
+        // given
+        Dashboard dashboard = dashboardRepository.save(createBackendDashboard());
+        Process process = processRepository.save(createInterviewProcess(dashboard));
+
+        // when
+        processFacade.delete(process.getId());
+
+        // then
+        assertThat(processRepository.findAll()).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/cruru/question/service/QuestionServiceTest.java
+++ b/backend/src/test/java/com/cruru/question/service/QuestionServiceTest.java
@@ -5,6 +5,7 @@ import static com.cruru.util.fixture.QuestionFixture.createLongAnswerQuestion;
 import static com.cruru.util.fixture.QuestionFixture.createShortAnswerQuestion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.cruru.applyform.domain.ApplyForm;
 import com.cruru.applyform.domain.repository.ApplyFormRepository;
@@ -62,7 +63,7 @@ class QuestionServiceTest extends ServiceTest {
         questionService.createAll(requests, applyForm);
 
         // then
-        List<Question> savedQuestions = questionRepository.findAllByApplyFormId(applyForm.getId());
+        List<Question> savedQuestions = questionRepository.findAllByApplyForm(applyForm);
         assertThat(savedQuestions).hasSize(requests.size());
     }
 
@@ -85,16 +86,28 @@ class QuestionServiceTest extends ServiceTest {
         Question question = questionService.create(request, applyForm);
 
         // then
-        List<Question> questions = questionRepository.findAllByApplyFormId(applyForm.getId());
+        List<Question> questions = questionRepository.findAllByApplyForm(applyForm);
         assertThat(questions).hasSize(1);
         assertThat(questions.get(0)).isEqualTo(question);
+    }
+
+    @DisplayName("질문 ID를 통해 특정 질문을 조회한다.")
+    @Test
+    void findById() {
+        // given
+        Question savedQuestion = questionRepository.save(createLongAnswerQuestion(null));
+
+        // when&then
+        assertDoesNotThrow(() -> questionService.findById(savedQuestion.getId()));
+        Question actualFoundQuestion = questionService.findById(savedQuestion.getId());
+        assertThat(actualFoundQuestion).isEqualTo(savedQuestion);
     }
 
     @DisplayName("Question 엔티티의 정보를 이용하여 Response DTO로 변경한다.")
     @ParameterizedTest()
     @MethodSource("provideQuestionsAndResponses")
     void toQuestionResponse(Question expectedQuestion, QuestionResponse actualResponse) {
-        // given & when & then
+        // given&when&then
         assertAll(() -> {
             assertThat(actualResponse.id()).isEqualTo(expectedQuestion.getId());
             assertThat(actualResponse.orderIndex()).isEqualTo(expectedQuestion.getSequence());

--- a/backend/src/test/java/com/cruru/util/fixture/ClubFixture.java
+++ b/backend/src/test/java/com/cruru/util/fixture/ClubFixture.java
@@ -1,10 +1,15 @@
 package com.cruru.util.fixture;
 
 import com.cruru.club.domain.Club;
+import com.cruru.member.domain.Member;
 
 public class ClubFixture {
 
     public static Club createClub() {
         return new Club("크루루", null);
+    }
+
+    public static Club createClub(Member member) {
+        return new Club("크루루", member);
     }
 }

--- a/backend/src/test/java/com/cruru/util/fixture/ProcessFixture.java
+++ b/backend/src/test/java/com/cruru/util/fixture/ProcessFixture.java
@@ -2,8 +2,19 @@ package com.cruru.util.fixture;
 
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.process.domain.Process;
+import java.util.List;
 
 public class ProcessFixture {
+
+    public static List<Process> maxSizeOf(Dashboard dashboard) {
+        return List.of(
+                createFirstProcess(dashboard),
+                new Process(1, "코딩 테스트", "온라인", dashboard),
+                new Process(2, "CS 테스트", "온라인", dashboard),
+                new Process(3, "1차 면접", "화상 면접", dashboard),
+                createFinalProcess(dashboard)
+        );
+    }
 
     public static Process createFirstProcess() {
         return new Process(0, "지원 접수", "지원자가 지원서를 제출하는 단계", null);


### PR DESCRIPTION
- #339 

## 목적
Process 도메인에 Facade Service를 도입합니다.


## 작업 세부사항
- [x] Process 도메인 관련 Service 로직 분리
- [x] Facade 적용
- [x] Process patch API response 수정
- [x] Test 수정 및 작성

## 참고 사항
bottom-up 방식으로 ERD상 하위 엔티티 도메인부터 작업을 진행해나갈 예정입니다.
완료된 PR의 경우 cherry-pick 또는 merge를 통해 본인의 코드에 적용해주세요



FACADE_ADOPTION_01-4