### PR TITLE
refactor-be(Member, Club): Facade Service 계층 도입

### DIFF
--- a/backend/src/main/java/com/cruru/club/controller/ClubController.java
+++ b/backend/src/main/java/com/cruru/club/controller/ClubController.java
@@ -1,7 +1,7 @@
 package com.cruru.club.controller;
 
 import com.cruru.club.controller.dto.ClubCreateRequest;
-import com.cruru.club.service.ClubService;
+import com.cruru.club.service.facade.ClubFacade;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -17,14 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ClubController {
 
-    private final ClubService clubService;
+    private final ClubFacade clubFacade;
 
     @PostMapping
     public ResponseEntity<Void> create(
             @RequestBody @Valid ClubCreateRequest request,
             @RequestParam(name = "memberId") Long memberId
     ) {
-        long clubId = clubService.create(request, memberId);
+        long clubId = clubFacade.create(request, memberId);
         return ResponseEntity.created(URI.create("/v1/clubs/" + clubId)).build();
     }
 }

--- a/backend/src/main/java/com/cruru/club/service/ClubService.java
+++ b/backend/src/main/java/com/cruru/club/service/ClubService.java
@@ -5,8 +5,6 @@ import com.cruru.club.domain.Club;
 import com.cruru.club.domain.repository.ClubRepository;
 import com.cruru.club.exception.ClubNotFoundException;
 import com.cruru.member.domain.Member;
-import com.cruru.member.domain.repository.MemberRepository;
-import com.cruru.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,15 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClubService {
 
     private final ClubRepository clubRepository;
-    private final MemberRepository memberRepository;
 
     @Transactional
-    public long create(ClubCreateRequest request, long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
-
-        Club club = clubRepository.save(new Club(request.name(), member));
-        return club.getId();
+    public Club create(ClubCreateRequest request, Member member) {
+        return clubRepository.save(new Club(request.name(), member));
     }
 
     public Club findById(long id) {

--- a/backend/src/main/java/com/cruru/club/service/facade/ClubFacade.java
+++ b/backend/src/main/java/com/cruru/club/service/facade/ClubFacade.java
@@ -1,0 +1,27 @@
+package com.cruru.club.service.facade;
+
+import com.cruru.club.controller.dto.ClubCreateRequest;
+import com.cruru.club.domain.Club;
+import com.cruru.club.service.ClubService;
+import com.cruru.member.domain.Member;
+import com.cruru.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ClubFacade {
+
+    private final ClubService clubService;
+    private final MemberService memberService;
+
+    @Transactional
+    public long create(ClubCreateRequest request, long memberId) {
+        Member clubOwner = memberService.findById(memberId);
+        Club createdClub = clubService.create(request, clubOwner);
+
+        return createdClub.getId();
+    }
+}

--- a/backend/src/main/java/com/cruru/member/controller/MemberController.java
+++ b/backend/src/main/java/com/cruru/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.cruru.member.controller;
 
 import com.cruru.member.controller.dto.MemberCreateRequest;
-import com.cruru.member.service.MemberService;
+import com.cruru.member.service.facade.MemberFacade;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
 
-    private final MemberService memberService;
+    private final MemberFacade memberFacade;
 
     @PostMapping
     public ResponseEntity<Void> create(@RequestBody @Valid MemberCreateRequest request) {
-        long memberId = memberService.create(request);
+        long memberId = memberFacade.create(request);
         return ResponseEntity.created(URI.create("/v1/members/" + memberId)).build();
     }
 }

--- a/backend/src/main/java/com/cruru/member/service/MemberService.java
+++ b/backend/src/main/java/com/cruru/member/service/MemberService.java
@@ -15,8 +15,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public long create(MemberCreateRequest request) {
-        Member member = memberRepository.save(new Member(request.email(), request.password(), request.phone()));
-        return member.getId();
+    public Member create(MemberCreateRequest request) {
+        return memberRepository.save(new Member(request.email(), request.password(), request.phone()));
     }
 }

--- a/backend/src/main/java/com/cruru/member/service/MemberService.java
+++ b/backend/src/main/java/com/cruru/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.cruru.member.service;
 import com.cruru.member.controller.dto.MemberCreateRequest;
 import com.cruru.member.domain.Member;
 import com.cruru.member.domain.repository.MemberRepository;
+import com.cruru.member.exception.MemberNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,5 +18,10 @@ public class MemberService {
     @Transactional
     public Member create(MemberCreateRequest request) {
         return memberRepository.save(new Member(request.email(), request.password(), request.phone()));
+    }
+
+    public Member findById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/backend/src/main/java/com/cruru/member/service/facade/MemberFacade.java
+++ b/backend/src/main/java/com/cruru/member/service/facade/MemberFacade.java
@@ -14,6 +14,7 @@ public class MemberFacade {
 
     private final MemberService memberService;
 
+    @Transactional
     public long create(MemberCreateRequest request) {
         Member savedMember = memberService.create(request);
         return savedMember.getId();

--- a/backend/src/main/java/com/cruru/member/service/facade/MemberFacade.java
+++ b/backend/src/main/java/com/cruru/member/service/facade/MemberFacade.java
@@ -1,0 +1,21 @@
+package com.cruru.member.service.facade;
+
+import com.cruru.member.controller.dto.MemberCreateRequest;
+import com.cruru.member.domain.Member;
+import com.cruru.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberFacade {
+
+    private final MemberService memberService;
+
+    public long create(MemberCreateRequest request) {
+        Member savedMember = memberService.create(request);
+        return savedMember.getId();
+    }
+}

--- a/backend/src/test/java/com/cruru/club/service/facade/ClubFacadeTest.java
+++ b/backend/src/test/java/com/cruru/club/service/facade/ClubFacadeTest.java
@@ -1,0 +1,49 @@
+package com.cruru.club.service.facade;
+
+import static com.cruru.util.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.cruru.club.controller.dto.ClubCreateRequest;
+import com.cruru.club.domain.Club;
+import com.cruru.member.domain.Member;
+import com.cruru.member.domain.repository.MemberRepository;
+import com.cruru.util.ServiceTest;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("동아리 파사드 서비스 테스트")
+class ClubFacadeTest extends ServiceTest {
+
+    @Autowired
+    private ClubFacade clubFacade;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @DisplayName("회원가입 되어있는 회원이 새로운 동아리를 생성한다.")
+    @Test
+    void create() {
+        // given
+        Member member = memberRepository.save(createMember());
+        ClubCreateRequest request = new ClubCreateRequest("연합동아리");
+
+        // when
+        long clubId = clubFacade.create(request, member.getId());
+
+        // then
+        Club actual = entityManager.createQuery(
+                        "SELECT c FROM Club c JOIN FETCH c.member WHERE c.id = :id", Club.class)
+                .setParameter("id", clubId)
+                .getSingleResult();
+        assertAll(() -> {
+            assertThat(actual.getMember()).isEqualTo(member);
+            assertThat(actual.getName()).isEqualTo(request.name());
+        });
+    }
+}

--- a/backend/src/test/java/com/cruru/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/cruru/member/service/MemberServiceTest.java
@@ -2,11 +2,13 @@ package com.cruru.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.cruru.member.controller.dto.MemberCreateRequest;
 import com.cruru.member.domain.Member;
 import com.cruru.member.domain.repository.MemberRepository;
 import com.cruru.util.ServiceTest;
+import com.cruru.util.fixture.MemberFixture;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,22 @@ class MemberServiceTest extends ServiceTest {
             Member presentMember = actualMember.get();
             assertThat(presentMember.getEmail()).isEqualTo(email);
             assertThat(presentMember.getPhone()).isEqualTo(phone);
+        });
+    }
+
+    @DisplayName("회원을 ID로 조회한다.")
+    @Test
+    void findById() {
+        // given
+        Member savedMember = memberRepository.save(MemberFixture.createMember());
+
+        // when&then
+        assertAll(() -> {
+            assertDoesNotThrow(() -> memberService.findById(savedMember.getId()));
+            Member actualMember = memberService.findById(savedMember.getId());
+            assertThat(actualMember.getEmail()).isEqualTo(savedMember.getEmail());
+            assertThat(actualMember.getPhone()).isEqualTo(savedMember.getPhone());
+            assertThat(actualMember.getPassword()).isEqualTo(savedMember.getPassword());
         });
     }
 }

--- a/backend/src/test/java/com/cruru/member/service/facade/MemberFacadeTest.java
+++ b/backend/src/test/java/com/cruru/member/service/facade/MemberFacadeTest.java
@@ -1,4 +1,4 @@
-package com.cruru.member.service;
+package com.cruru.member.service.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -12,11 +12,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@DisplayName("사용자 서비스 테스트")
-class MemberServiceTest extends ServiceTest {
+@DisplayName("회원 파사드 서비스 테스트")
+class MemberFacadeTest extends ServiceTest {
 
     @Autowired
-    private MemberService memberService;
+    private MemberFacade memberFacade;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -31,15 +31,15 @@ class MemberServiceTest extends ServiceTest {
         MemberCreateRequest request = new MemberCreateRequest(email, password, phone);
 
         // when
-        Member member = memberService.create(request);
+        long memberId = memberFacade.create(request);
 
         // then
-        Optional<Member> actualMember = memberRepository.findById(member.getId());
+        Optional<Member> member = memberRepository.findById(memberId);
         assertAll(() -> {
-            assertThat(actualMember).isPresent();
-            Member presentMember = actualMember.get();
-            assertThat(presentMember.getEmail()).isEqualTo(email);
-            assertThat(presentMember.getPhone()).isEqualTo(phone);
+            assertThat(member).isPresent();
+            Member presentMemeber = member.get();
+            assertThat(presentMemeber.getEmail()).isEqualTo(email);
+            assertThat(presentMemeber.getPhone()).isEqualTo(phone);
         });
     }
 }

--- a/backend/src/test/java/com/cruru/util/fixture/ClubFixture.java
+++ b/backend/src/test/java/com/cruru/util/fixture/ClubFixture.java
@@ -1,10 +1,15 @@
 package com.cruru.util.fixture;
 
 import com.cruru.club.domain.Club;
+import com.cruru.member.domain.Member;
 
 public class ClubFixture {
 
     public static Club createClub() {
         return new Club("크루루", null);
+    }
+
+    public static Club createClub(Member member) {
+        return new Club("크루루", member);
     }
 }


### PR DESCRIPTION
- #356 
- #357
 
 ## 목적
Member, Club 도메인에 Facade Service를 도입합니다.


## 작업 세부사항
- [x] Member, Club 도메인 관련 Service 로직 분리
- [x] Test 수정 및 작성

## 참고 사항
bottom-up 방식으로 ERD상 하위 엔티티 도메인부터 작업을 진행해나갈 예정입니다.
완료된 PR의 경우 cherry-pick 또는 merge를 통해 본인의 코드에 적용해주세요

Member와 Club은 변경사항이 적어서 합쳐서 진행했습니다

FACADE_ADOPTION_01-6