### PR TITLE
feat-be: Applicant 관련 API 쿼리 최적화

### DIFF
--- a/backend/src/main/java/com/cruru/applicant/facade/ApplicantFacade.java
+++ b/backend/src/main/java/com/cruru/applicant/facade/ApplicantFacade.java
@@ -40,7 +40,7 @@ public class ApplicantFacade {
 
     public ApplicantAnswerResponses readDetailById(long applicantId) {
         Applicant applicant = applicantService.findById(applicantId);
-        List<Answer> answers = answerService.findAllByApplicant(applicant);
+        List<Answer> answers = answerService.findAllByApplicantWithQuestions(applicant);
         List<AnswerResponse> answerResponses = answerService.toAnswerResponses(answers);
         return new ApplicantAnswerResponses(answerResponses);
     }

--- a/backend/src/main/java/com/cruru/question/domain/repository/AnswerRepository.java
+++ b/backend/src/main/java/com/cruru/question/domain/repository/AnswerRepository.java
@@ -4,8 +4,11 @@ import com.cruru.applicant.domain.Applicant;
 import com.cruru.question.domain.Answer;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
-    List<Answer> findAllByApplicant(Applicant applicant);
+    @Query("SELECT a FROM Answer a JOIN FETCH a.question WHERE a.applicant = :applicant")
+    List<Answer> findAllByApplicantWithQuestions(@Param("applicant") Applicant applicant);
 }

--- a/backend/src/main/java/com/cruru/question/service/AnswerService.java
+++ b/backend/src/main/java/com/cruru/question/service/AnswerService.java
@@ -40,8 +40,8 @@ public class AnswerService {
         }
     }
 
-    public List<Answer> findAllByApplicant(Applicant applicant) {
-        return answerRepository.findAllByApplicant(applicant);
+    public List<Answer> findAllByApplicantWithQuestions(Applicant applicant) {
+        return answerRepository.findAllByApplicantWithQuestions(applicant);
     }
 
     public List<AnswerResponse> toAnswerResponses(List<Answer> answers) {

--- a/backend/src/test/java/com/cruru/question/domain/repository/AnswerRepositoryTest.java
+++ b/backend/src/test/java/com/cruru/question/domain/repository/AnswerRepositoryTest.java
@@ -1,11 +1,20 @@
 package com.cruru.question.domain.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.domain.repository.ApplicantRepository;
+import com.cruru.process.domain.Process;
+import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.question.domain.Answer;
 import com.cruru.question.domain.Question;
 import com.cruru.util.RepositoryTest;
+import com.cruru.util.fixture.AnswerFixture;
+import com.cruru.util.fixture.ApplicantFixture;
+import com.cruru.util.fixture.ProcessFixture;
 import com.cruru.util.fixture.QuestionFixture;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +25,15 @@ class AnswerRepositoryTest extends RepositoryTest {
 
     @Autowired
     private AnswerRepository answerRepository;
+
+    @Autowired
+    private ProcessRepository processRepository;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
 
     @BeforeEach
     void setUp() {
@@ -53,5 +71,26 @@ class AnswerRepositoryTest extends RepositoryTest {
 
         //then
         assertThat(savedAnswer1.getId() + 1).isEqualTo(savedAnswer2.getId());
+    }
+
+    @DisplayName("특정 지원자와 질문에 해당하는 답변 목록을 조회한다.")
+    @Test
+    void findAllByApplicantWithQuestions() {
+        // given
+        Process process = processRepository.save(ProcessFixture.applyType());
+        Applicant applicant = applicantRepository.save(ApplicantFixture.pendingDobby(process));
+        Question question = questionRepository.save(QuestionFixture.shortAnswerType(null));
+        answerRepository.save(AnswerFixture.first(question, applicant));
+
+        // when
+        List<Answer> actual = answerRepository.findAllByApplicantWithQuestions(applicant);
+
+        // then
+        Answer actualAnswer = actual.get(0);
+        assertAll(
+                () -> assertThat(actual).hasSize(1),
+                () -> assertThat(actualAnswer.getQuestion()).isEqualTo(question),
+                () -> assertThat(actualAnswer.getApplicant()).isEqualTo(applicant)
+        );
     }
 }

--- a/backend/src/test/java/com/cruru/question/service/AnswerServiceTest.java
+++ b/backend/src/test/java/com/cruru/question/service/AnswerServiceTest.java
@@ -61,7 +61,7 @@ class AnswerServiceTest extends ServiceTest {
         answerService.saveAnswerReplies(request, question1, applicant);
 
         // then
-        List<Answer> actualAnswer = answerRepository.findAllByApplicant(applicant);
+        List<Answer> actualAnswer = answerRepository.findAllByApplicantWithQuestions(applicant);
         String content = actualAnswer.get(0).getContent();
         assertAll(
                 () -> assertThat(actualAnswer).hasSize(1),
@@ -81,7 +81,7 @@ class AnswerServiceTest extends ServiceTest {
         answerService.saveAnswerReplies(request, question, applicant);
 
         // then
-        List<Answer> actualAnswer = answerRepository.findAllByApplicant(applicant);
+        List<Answer> actualAnswer = answerRepository.findAllByApplicantWithQuestions(applicant);
         String content = actualAnswer.get(0).getContent();
         assertAll(
                 () -> assertThat(actualAnswer).hasSize(1),
@@ -112,7 +112,7 @@ class AnswerServiceTest extends ServiceTest {
         ));
 
         // when
-        List<Answer> actualAnswers = answerService.findAllByApplicant(applicant);
+        List<Answer> actualAnswers = answerService.findAllByApplicantWithQuestions(applicant);
 
         // then
         assertThat(actualAnswers).hasSameElementsAs(expectedAnswers);


### PR DESCRIPTION
## 작업 내용
지원자의 응답 조회 API 요청 시 발생하는 쿼리의 개수를 줄였습니다.
- **문제 상황**: N+1 문제 발생
기존에는 Answer를 조회할 때마다 Answer에 해당하는 Question을 별도의 쿼리로 조회하여 N+1 문제가 발생하였습니다.
- **문제 해결**: 페치 조인 적용
페치 조인을 적용하여, Answer와 Question을 하나의 쿼리로 함께 조회하도록 변경하였습니다.

    ```java
    @Query("SELECT a FROM Answer a JOIN FETCH a.question WHERE a.applicant = :applicant")
    List<Answer> findAllByApplicantWithQuestions(@Param("applicant") Applicant applicant);
    ```
- **결과**
    ```sql
    // 최적화 전
    select a1_0.answer_id,a1_0.applicant_id,a1_0.content,a1_0.question_id from answer a1_0 where a1_0.applicant_id=?
    select q1_0.question_id,q1_0.apply_form_id,q1_0.content,q1_0.question_type,q1_0.required,q1_0.sequence from question q1_0 where q1_0.question_id=?
    select q1_0.question_id,q1_0.apply_form_id,q1_0.content,q1_0.question_type,q1_0.required,q1_0.sequence from question q1_0 where q1_0.question_id=?
    select q1_0.question_id,q1_0.apply_form_id,q1_0.content,q1_0.question_type,q1_0.required,q1_0.sequence from question q1_0 where q1_0.question_id=?
    select q1_0.question_id,q1_0.apply_form_id,q1_0.content,q1_0.question_type,q1_0.required,q1_0.sequence from question q1_0 where q1_0.question_id=?
    select q1_0.question_id,q1_0.apply_form_id,q1_0.content,q1_0.question_type,q1_0.required,q1_0.sequence from question q1_0 where q1_0.question_id=?

    // 최적화 후
    select a1_0.answer_id,a1_0.applicant_id,a1_0.content,q1_0.question_id,
       q1_0.apply_form_id,q1_0.content,q1_0.question_type,q1_0.required,q1_0.sequence 
    from answer a1_0 join question q1_0 on q1_0.question_id=a1_0.question_id 
    where a1_0.applicant_id=?
    ```

## 참고 사항
[노션 관련 페이지 링크](https://www.notion.so/dobbyss/cc7cbccc238a419689be7db9cdaab829?p=fff1e50d803f81e48decf26d7d81f102&pm=s)

## 관련 이슈
- #705 

## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?
