### PR TITLE
[BE] Release-HotFix: Cruru v1.1.1

### DIFF
--- a/.github/workflows/be-cd_prod-docker.yml
+++ b/.github/workflows/be-cd_prod-docker.yml
@@ -65,7 +65,8 @@ jobs:
   deploy:
     environment: prod
     strategy:
-      max-parallel: 2
+      fail-fast: true
+      max-parallel: 1
       matrix:
         runners: [be-prod-a, be-prod-b]
       
@@ -138,3 +139,6 @@ jobs:
     - name: Deploy docker container
       run: |
         sudo docker-compose --env-file .env -f docker-compose.prod.yml up -d
+
+    - name: Run server status check script with timeout
+      run: ../check_server_status_with_timeout.sh

--- a/backend/src/docs/asciidoc/applicant.adoc
+++ b/backend/src/docs/asciidoc/applicant.adoc
@@ -67,3 +67,31 @@ operation::applicant/change-info[snippets="http-request,path-parameters,request-
 ==== 실패: 존재하지 않는 지원자
 
 operation::applicant/change-info-fail/applicant-not-found[snippets="http-request,path-parameters,request-cookies,http-response"]
+
+=== 지원자 일괄 불합격
+
+==== 성공
+
+operation::applicant/reject-all/[snippets="http-request,request-cookies,request-fields,http-response"]
+
+==== 실패: 존재하지 않는 지원자
+
+operation::applicant/reject-all-fail/applicant-not-found[snippets="http-request,request-cookies,request-fields,http-response"]
+
+==== 실패: 이미 불합격한 지원자
+
+operation::applicant/reject-all-fail/already-rejected[snippets="http-request,request-cookies,request-fields,http-response"]
+
+=== 지원자 일괄 불합격 해제
+
+==== 성공
+
+operation::applicant/unreject-all/[snippets="http-request,request-cookies,request-fields,http-response"]
+
+==== 실패: 존재하지 않는 지원자
+
+operation::applicant/unreject-all-fail/applicant-not-found[snippets="http-request,request-cookies,request-fields,http-response"]
+
+==== 실패: 불합격 하지 않은 지원자
+
+operation::applicant/unreject-all-fail/already-unrejected[snippets="http-request,request-cookies,request-fields,http-response"]

--- a/backend/src/docs/asciidoc/dashboard.adoc
+++ b/backend/src/docs/asciidoc/dashboard.adoc
@@ -19,3 +19,13 @@ operation::dashboard/create-fail/club-not-found[snippets="http-request,request-c
 ==== 성공
 
 operation::dashboard/read[snippets="http-request,request-cookies,query-parameters,http-response,response-fields"]
+
+=== 대시보드 삭제
+
+==== 성공
+
+operation::dashboard/delete[snippets="http-request,request-cookies,path-parameters,http-response"]
+
+==== 실패: 존재하지 않는 대시보드
+
+operation::dashboard/delete/not-found[snippets="http-request,request-cookies,path-parameters,http-response"]

--- a/backend/src/docs/asciidoc/process.adoc
+++ b/backend/src/docs/asciidoc/process.adoc
@@ -4,7 +4,7 @@
 
 ==== 성공
 
-operation::process/read[snippets="http-request,request-cookies,query-parameters,http-response,response-fields"]
+operation::process/read-filter-and-order[snippets="http-request,request-cookies,query-parameters,http-response,response-fields"]
 
 ==== 실패: 존재하지 않는 대시보드
 

--- a/backend/src/main/java/com/cruru/applicant/controller/ApplicantController.java
+++ b/backend/src/main/java/com/cruru/applicant/controller/ApplicantController.java
@@ -2,6 +2,7 @@ package com.cruru.applicant.controller;
 
 import com.cruru.applicant.controller.request.ApplicantMoveRequest;
 import com.cruru.applicant.controller.request.ApplicantUpdateRequest;
+import com.cruru.applicant.controller.request.ApplicantsRejectRequest;
 import com.cruru.applicant.controller.response.ApplicantAnswerResponses;
 import com.cruru.applicant.controller.response.ApplicantBasicResponse;
 import com.cruru.applicant.domain.Applicant;
@@ -77,6 +78,20 @@ public class ApplicantController {
     @PatchMapping("/{applicantId}/unreject")
     public ResponseEntity<Void> unreject(@PathVariable Long applicantId, LoginProfile loginProfile) {
         applicantFacade.unreject(applicantId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/reject")
+    public ResponseEntity<Void> reject(@RequestBody @Valid ApplicantsRejectRequest request, LoginProfile loginProfile) {
+        applicantFacade.reject(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/unreject")
+    public ResponseEntity<Void> unreject(
+            @RequestBody @Valid ApplicantsRejectRequest request, LoginProfile loginProfile
+    ) {
+        applicantFacade.unreject(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/cruru/applicant/controller/EvaluationController.java
+++ b/backend/src/main/java/com/cruru/applicant/controller/EvaluationController.java
@@ -3,11 +3,11 @@ package com.cruru.applicant.controller;
 import com.cruru.applicant.controller.request.EvaluationCreateRequest;
 import com.cruru.applicant.controller.request.EvaluationUpdateRequest;
 import com.cruru.applicant.controller.response.EvaluationResponses;
-import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.Evaluation;
 import com.cruru.applicant.facade.EvaluationFacade;
 import com.cruru.auth.annotation.RequireAuthCheck;
 import com.cruru.global.LoginProfile;
+import com.cruru.process.domain.Process;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +28,7 @@ public class EvaluationController {
 
     private final EvaluationFacade evaluationFacade;
 
-    @RequireAuthCheck(targetId = "applicantId", targetDomain = Applicant.class)
+    @RequireAuthCheck(targetId = "processId", targetDomain = Process.class)
     @PostMapping
     public ResponseEntity<Void> create(
             @RequestBody @Valid EvaluationCreateRequest request,
@@ -41,7 +41,7 @@ public class EvaluationController {
         return ResponseEntity.created(URI.create(url)).build();
     }
 
-    @RequireAuthCheck(targetId = "applicantId", targetDomain = Applicant.class)
+    @RequireAuthCheck(targetId = "processId", targetDomain = Process.class)
     @GetMapping
     public ResponseEntity<EvaluationResponses> read(
             @RequestParam(name = "processId") Long processId,

--- a/backend/src/main/java/com/cruru/applicant/controller/request/ApplicantsRejectRequest.java
+++ b/backend/src/main/java/com/cruru/applicant/controller/request/ApplicantsRejectRequest.java
@@ -1,0 +1,11 @@
+package com.cruru.applicant.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record ApplicantsRejectRequest(
+        @NotNull(message = "지원자 목록은 필수 값입니다.")
+        List<Long> applicantIds
+) {
+
+}

--- a/backend/src/main/java/com/cruru/applicant/domain/ApplicantSortOption.java
+++ b/backend/src/main/java/com/cruru/applicant/domain/ApplicantSortOption.java
@@ -1,0 +1,41 @@
+package com.cruru.applicant.domain;
+
+import com.cruru.applicant.domain.dto.ApplicantCard;
+import com.cruru.applicant.exception.badrequest.ApplicantSortException;
+import java.util.Arrays;
+import java.util.Comparator;
+
+public enum ApplicantSortOption {
+
+    ASC(Comparator.naturalOrder()),
+    DESC(Comparator.reverseOrder());
+
+    private final Comparator<Comparable> comparator;
+
+    ApplicantSortOption(Comparator<Comparable> comparator) {
+        this.comparator = comparator;
+    }
+
+    public static Comparator<ApplicantCard> getCombinedComparator(String sortByCreatedAt, String sortByScore) {
+        ApplicantSortOption createdAtOption = convertToSortOption(sortByCreatedAt);
+        ApplicantSortOption scoreOption = convertToSortOption(sortByScore);
+
+        return createdAtOption.getCreatedAtComparator()
+                .thenComparing(scoreOption.getScoreComparator());
+    }
+
+    private static ApplicantSortOption convertToSortOption(String sortOption) {
+        return Arrays.stream(ApplicantSortOption.values())
+                .filter(option -> option.name().equalsIgnoreCase(sortOption))
+                .findAny()
+                .orElseThrow(ApplicantSortException::new);
+    }
+
+    private Comparator<ApplicantCard> getCreatedAtComparator() {
+        return Comparator.comparing(ApplicantCard::createdAt, comparator);
+    }
+
+    private Comparator<ApplicantCard> getScoreComparator() {
+        return Comparator.comparing(ApplicantCard::averageScore, comparator);
+    }
+}

--- a/backend/src/main/java/com/cruru/applicant/domain/Evaluation.java
+++ b/backend/src/main/java/com/cruru/applicant/domain/Evaluation.java
@@ -65,7 +65,7 @@ public class Evaluation extends BaseEntity implements SecureResource {
 
     @Override
     public boolean isAuthorizedBy(Member member) {
-        return applicant.isAuthorizedBy(member);
+        return process.isAuthorizedBy(member);
     }
 
     @Override

--- a/backend/src/main/java/com/cruru/applicant/domain/EvaluationStatus.java
+++ b/backend/src/main/java/com/cruru/applicant/domain/EvaluationStatus.java
@@ -1,0 +1,28 @@
+package com.cruru.applicant.domain;
+
+import com.cruru.applicant.domain.dto.ApplicantCard;
+import com.cruru.applicant.exception.badrequest.EvaluationStatusException;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+public enum EvaluationStatus {
+
+    ALL(card -> true),
+    NOT_EVALUATED(ApplicantCard::hasEvaluation),
+    EVALUATED(ApplicantCard::hasNoEvaluation);
+
+    private final Predicate<ApplicantCard> predicate;
+
+    EvaluationStatus(Predicate<ApplicantCard> predicate) {
+        this.predicate = predicate;
+    }
+
+    public static boolean matches(ApplicantCard card, String evaluationStatus) {
+        return Arrays.stream(EvaluationStatus.values())
+                .filter(status -> status.name().equalsIgnoreCase(evaluationStatus))
+                .findAny()
+                .orElseThrow(EvaluationStatusException::new)
+                .predicate
+                .test(card);
+    }
+}

--- a/backend/src/main/java/com/cruru/applicant/domain/dto/ApplicantCard.java
+++ b/backend/src/main/java/com/cruru/applicant/domain/dto/ApplicantCard.java
@@ -22,4 +22,12 @@ public record ApplicantCard(
     public ApplicantCardResponse toResponse() {
         return new ApplicantCardResponse(id, name, createdAt, isRejected, (int) evaluationCount, averageScore);
     }
+
+    public boolean hasEvaluation() {
+        return evaluationCount == 0;
+    }
+
+    public boolean hasNoEvaluation() {
+        return evaluationCount > 0;
+    }
 }

--- a/backend/src/main/java/com/cruru/applicant/domain/repository/ApplicantRepository.java
+++ b/backend/src/main/java/com/cruru/applicant/domain/repository/ApplicantRepository.java
@@ -5,13 +5,21 @@ import com.cruru.applicant.domain.dto.ApplicantCard;
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.process.domain.Process;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
     List<Applicant> findAllByProcess(Process process);
+
+    @EntityGraph(attributePaths = {"process.dashboard.club.member"})
+    @Query("SELECT a FROM Applicant a WHERE a.id = :id")
+    Optional<Applicant> findByIdFetchingMember(long id);
 
     long countByProcess(Process process);
 
@@ -39,4 +47,13 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
     @Query("SELECT a FROM Applicant a JOIN FETCH a.process p JOIN FETCH p.dashboard d WHERE d = :dashboard")
     List<Applicant> findAllByDashboard(@Param("dashboard") Dashboard dashboard);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+           UPDATE Applicant a
+           SET a.isRejected = :isRejected
+           WHERE a.id in :applicantIds
+           """)
+    @Transactional
+    void updateRejectedStatusForApplicants(List<Long> applicantIds, boolean isRejected);
 }

--- a/backend/src/main/java/com/cruru/applicant/domain/repository/EvaluationRepository.java
+++ b/backend/src/main/java/com/cruru/applicant/domain/repository/EvaluationRepository.java
@@ -4,11 +4,26 @@ import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.Evaluation;
 import com.cruru.process.domain.Process;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface EvaluationRepository extends JpaRepository<Evaluation, Long> {
 
     List<Evaluation> findAllByProcessAndApplicant(Process process, Applicant applicant);
 
     void deleteByProcessId(long processId);
+
+    @EntityGraph(attributePaths = {"process.dashboard.club.member"})
+    @Query("SELECT e FROM Evaluation e WHERE e.id = :id")
+    Optional<Evaluation> findByIdFetchingMember(long id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Evaluation e WHERE e.process IN :processes")
+    void deleteAllByProcesses(@Param("processes") List<Process> processes);
 }

--- a/backend/src/main/java/com/cruru/applicant/exception/badrequest/ApplicantSortException.java
+++ b/backend/src/main/java/com/cruru/applicant/exception/badrequest/ApplicantSortException.java
@@ -1,0 +1,12 @@
+package com.cruru.applicant.exception.badrequest;
+
+import com.cruru.advice.badrequest.BadRequestException;
+
+public class ApplicantSortException extends BadRequestException {
+
+    private static final String MESSAGE = "지원하는 정렬 조건이 아닙니다.";
+
+    public ApplicantSortException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/cruru/applicant/exception/badrequest/EvaluationStatusException.java
+++ b/backend/src/main/java/com/cruru/applicant/exception/badrequest/EvaluationStatusException.java
@@ -1,0 +1,12 @@
+package com.cruru.applicant.exception.badrequest;
+
+import com.cruru.advice.badrequest.BadRequestException;
+
+public class EvaluationStatusException extends BadRequestException {
+
+    private static final String MESSAGE = "지원하는 평가 상태가 아닙니다.";
+
+    public EvaluationStatusException() {
+        super(MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/cruru/applicant/facade/ApplicantFacade.java
+++ b/backend/src/main/java/com/cruru/applicant/facade/ApplicantFacade.java
@@ -2,6 +2,7 @@ package com.cruru.applicant.facade;
 
 import com.cruru.applicant.controller.request.ApplicantMoveRequest;
 import com.cruru.applicant.controller.request.ApplicantUpdateRequest;
+import com.cruru.applicant.controller.request.ApplicantsRejectRequest;
 import com.cruru.applicant.controller.response.ApplicantAnswerResponses;
 import com.cruru.applicant.controller.response.ApplicantBasicResponse;
 import com.cruru.applicant.controller.response.ApplicantResponse;
@@ -64,5 +65,15 @@ public class ApplicantFacade {
     @Transactional
     public void unreject(long applicantId) {
         applicantService.unreject(applicantId);
+    }
+
+    @Transactional
+    public void reject(ApplicantsRejectRequest request) {
+        applicantService.reject(request.applicantIds());
+    }
+
+    @Transactional
+    public void unreject(ApplicantsRejectRequest request) {
+        applicantService.unreject(request.applicantIds());
     }
 }

--- a/backend/src/main/java/com/cruru/applicant/service/EvaluationService.java
+++ b/backend/src/main/java/com/cruru/applicant/service/EvaluationService.java
@@ -24,6 +24,11 @@ public class EvaluationService {
                 .orElseThrow(EvaluationNotFoundException::new);
     }
 
+    public Evaluation findByIdFetchingMember(Long evaluationId) {
+        return evaluationRepository.findByIdFetchingMember(evaluationId)
+                .orElseThrow(EvaluationNotFoundException::new);
+    }
+
     @Transactional
     public void create(EvaluationCreateRequest request, Process process, Applicant applicant) {
         evaluationRepository.save(new Evaluation(request.score(), request.content(), process, applicant));
@@ -52,7 +57,13 @@ public class EvaluationService {
         return !(evaluation.getContent().equals(request.content()) && evaluation.getScore().equals(request.score()));
     }
 
+    @Transactional
     public void deleteByProcess(long processId) {
         evaluationRepository.deleteByProcessId(processId);
+    }
+
+    @Transactional
+    public void deleteAllByProcesses(List<Process> processes) {
+        evaluationRepository.deleteAllByProcesses(processes);
     }
 }

--- a/backend/src/main/java/com/cruru/applyform/domain/repository/ApplyFormRepository.java
+++ b/backend/src/main/java/com/cruru/applyform/domain/repository/ApplyFormRepository.java
@@ -5,11 +5,16 @@ import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.dashboard.domain.DashboardApplyFormDto;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ApplyFormRepository extends JpaRepository<ApplyForm, Long> {
+
+    @EntityGraph(attributePaths = {"dashboard.club.member"})
+    @Query("SELECT a FROM ApplyForm a WHERE a.id = :id")
+    Optional<ApplyForm> findByIdFetchingMember(long id);
 
     Optional<ApplyForm> findByDashboard(Dashboard dashboard);
 

--- a/backend/src/main/java/com/cruru/applyform/service/ApplyFormService.java
+++ b/backend/src/main/java/com/cruru/applyform/service/ApplyFormService.java
@@ -77,6 +77,11 @@ public class ApplyFormService {
                 .orElseThrow(ApplyFormNotFoundException::new);
     }
 
+    public ApplyForm findByIdFetchingMember(Long applyFormId) {
+        return applyFormRepository.findByIdFetchingMember(applyFormId)
+                .orElseThrow(ApplyFormNotFoundException::new);
+    }
+
     public ApplyForm findByDashboardId(Long dashboardId) {
         return applyFormRepository.findByDashboardId(dashboardId)
                 .orElseThrow(ApplyFormNotFoundException::new);
@@ -85,5 +90,10 @@ public class ApplyFormService {
     public ApplyForm findByDashboard(Dashboard dashboard) {
         return applyFormRepository.findByDashboard(dashboard)
                 .orElseThrow(ApplyFormNotFoundException::new);
+    }
+
+    @Transactional
+    public void delete(ApplyForm applyForm) {
+        applyFormRepository.delete(applyForm);
     }
 }

--- a/backend/src/main/java/com/cruru/auth/aspect/AuthCheckAspect.java
+++ b/backend/src/main/java/com/cruru/auth/aspect/AuthCheckAspect.java
@@ -100,7 +100,7 @@ public class AuthCheckAspect {
         Object service = applicationContext.getBean(serviceName);
 
         // findById 메서드를 호출하여 해당 도메인 객체(SecureResource)를 가져옴
-        Method findByIdMethod = service.getClass().getMethod("findById", Long.class);
+        Method findByIdMethod = service.getClass().getMethod("findByIdFetchingMember", Long.class);
         SecureResource secureResource = (SecureResource) findByIdMethod.invoke(service, targetId);
 
         // Lazy Loading된 연관 엔티티를 강제 로딩함

--- a/backend/src/main/java/com/cruru/club/domain/repository/ClubRepository.java
+++ b/backend/src/main/java/com/cruru/club/domain/repository/ClubRepository.java
@@ -3,9 +3,15 @@ package com.cruru.club.domain.repository;
 import com.cruru.club.domain.Club;
 import com.cruru.member.domain.Member;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ClubRepository extends JpaRepository<Club, Long> {
 
     Optional<Club> findByMember(Member member);
+
+    @EntityGraph(attributePaths = "member")
+    @Query("SELECT c FROM Club c WHERE c.id = :id")
+    Optional<Club> findByIdFetchingMember(long id);
 }

--- a/backend/src/main/java/com/cruru/club/service/ClubService.java
+++ b/backend/src/main/java/com/cruru/club/service/ClubService.java
@@ -35,4 +35,9 @@ public class ClubService {
         return clubRepository.findByMember(member)
                 .orElseThrow(ClubNotFoundException::new);
     }
+
+    public Club findByIdFetchingMember(Long id) {
+        return clubRepository.findByIdFetchingMember(id)
+                .orElseThrow(ClubNotFoundException::new);
+    }
 }

--- a/backend/src/main/java/com/cruru/dashboard/controller/DashboardController.java
+++ b/backend/src/main/java/com/cruru/dashboard/controller/DashboardController.java
@@ -5,13 +5,16 @@ import com.cruru.club.domain.Club;
 import com.cruru.dashboard.controller.request.DashboardCreateRequest;
 import com.cruru.dashboard.controller.response.DashboardCreateResponse;
 import com.cruru.dashboard.controller.response.DashboardsOfClubResponse;
+import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.dashboard.facade.DashboardFacade;
 import com.cruru.global.LoginProfile;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,5 +49,12 @@ public class DashboardController {
     ) {
         DashboardsOfClubResponse dashboards = dashboardFacade.findAllDashboardsByClubId(clubId);
         return ResponseEntity.ok().body(dashboards);
+    }
+
+    @DeleteMapping("/{dashboardId}")
+    @RequireAuthCheck(targetId = "dashboardId", targetDomain = Dashboard.class)
+    public ResponseEntity<Void> delete(@PathVariable Long dashboardId, LoginProfile loginProfile) {
+        dashboardFacade.delete(dashboardId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/cruru/dashboard/domain/repository/DashboardRepository.java
+++ b/backend/src/main/java/com/cruru/dashboard/domain/repository/DashboardRepository.java
@@ -1,8 +1,14 @@
 package com.cruru.dashboard.domain.repository;
 
 import com.cruru.dashboard.domain.Dashboard;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
 
+    @EntityGraph(attributePaths = {"club.member"})
+    @Query("SELECT d FROM Dashboard d WHERE d.id = :id")
+    Optional<Dashboard> findByIdFetchingMember(long id);
 }

--- a/backend/src/main/java/com/cruru/dashboard/service/DashboardService.java
+++ b/backend/src/main/java/com/cruru/dashboard/service/DashboardService.java
@@ -41,11 +41,21 @@ public class DashboardService {
                 .orElseThrow(DashboardNotFoundException::new);
     }
 
+    public Dashboard findByIdFetchingMember(Long id) {
+        return dashboardRepository.findByIdFetchingMember(id)
+                .orElseThrow(DashboardNotFoundException::new);
+    }
+
     public List<DashboardApplyFormDto> findAllByClub(long clubId) {
         return applyFormRepository.findAllByClub(clubId);
     }
 
     public List<Applicant> findAllApplicants(Dashboard dashboard) {
         return applicantRepository.findAllByDashboard(dashboard);
+    }
+
+    @Transactional
+    public void deleteById(Long dashboardId) {
+        dashboardRepository.deleteById(dashboardId);
     }
 }

--- a/backend/src/main/java/com/cruru/email/domain/repository/EmailRepository.java
+++ b/backend/src/main/java/com/cruru/email/domain/repository/EmailRepository.java
@@ -1,8 +1,18 @@
 package com.cruru.email.domain.repository;
 
+import com.cruru.applicant.domain.Applicant;
 import com.cruru.email.domain.Email;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface EmailRepository extends JpaRepository<Email, Long> {
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Email e WHERE e.to IN :tos")
+    void deleteAllByTos(@Param("tos") List<Applicant> tos);
 }

--- a/backend/src/main/java/com/cruru/email/service/EmailService.java
+++ b/backend/src/main/java/com/cruru/email/service/EmailService.java
@@ -74,4 +74,9 @@ public class EmailService {
     public void save(Email email) {
         emailRepository.save(email);
     }
+
+    @Transactional
+    public void deleteAllByTos(List<Applicant> applicants) {
+        emailRepository.deleteAllByTos(applicants);
+    }
 }

--- a/backend/src/main/java/com/cruru/global/util/ExceptionLogger.java
+++ b/backend/src/main/java/com/cruru/global/util/ExceptionLogger.java
@@ -47,6 +47,9 @@ public class ExceptionLogger {
 
     private static void setMDC(ProblemDetail problemDetail) {
         Map<String, Object> details = problemDetail.getProperties();
+        if (details == null || details.isEmpty()) {
+            return;
+        }
         Map<String, String> map = new HashMap<>();
         for (Entry<String, Object> stringObjectEntry : details.entrySet()) {
             map.put(stringObjectEntry.getKey(), java.lang.String.valueOf(stringObjectEntry.getValue()));

--- a/backend/src/main/java/com/cruru/process/controller/ProcessController.java
+++ b/backend/src/main/java/com/cruru/process/controller/ProcessController.java
@@ -33,9 +33,17 @@ public class ProcessController {
     @RequireAuthCheck(targetId = "dashboardId", targetDomain = Dashboard.class)
     @GetMapping
     public ResponseEntity<ProcessResponses> read(
-            LoginProfile loginProfile, @RequestParam(name = "dashboardId") Long dashboardId
+            LoginProfile loginProfile,
+            @RequestParam(name = "dashboardId") Long dashboardId,
+            @RequestParam(name = "minScore", required = false, defaultValue = "0.00") Double minScore,
+            @RequestParam(name = "maxScore", required = false, defaultValue = "5.00") Double maxScore,
+            @RequestParam(name = "evaluationStatus", required = false, defaultValue = "ALL") String evaluationStatus,
+            @RequestParam(name = "sortByCreatedAt", required = false, defaultValue = "DESC") String sortByCreatedAt,
+            @RequestParam(name = "sortByScore", required = false, defaultValue = "DESC") String sortByScore
     ) {
-        ProcessResponses processes = processFacade.readAllByDashboardId(dashboardId);
+        ProcessResponses processes = processFacade.readAllByDashboardId(
+                dashboardId, minScore, maxScore, evaluationStatus, sortByCreatedAt, sortByScore
+        );
         return ResponseEntity.ok().body(processes);
     }
 

--- a/backend/src/main/java/com/cruru/process/domain/repository/ProcessRepository.java
+++ b/backend/src/main/java/com/cruru/process/domain/repository/ProcessRepository.java
@@ -3,7 +3,10 @@ package com.cruru.process.domain.repository;
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.process.domain.Process;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProcessRepository extends JpaRepository<Process, Long> {
 
@@ -12,4 +15,8 @@ public interface ProcessRepository extends JpaRepository<Process, Long> {
     int countByDashboard(Dashboard dashboard);
 
     List<Process> findAllByDashboard(Dashboard dashboard);
+
+    @EntityGraph(attributePaths = {"dashboard.club.member"})
+    @Query("SELECT p FROM Process p WHERE p.id = :id")
+    Optional<Process> findByIdFetchingMember(long id);
 }

--- a/backend/src/main/java/com/cruru/process/facade/ProcessFacade.java
+++ b/backend/src/main/java/com/cruru/process/facade/ProcessFacade.java
@@ -36,10 +36,19 @@ public class ProcessFacade {
         processService.create(request, dashboard);
     }
 
-    public ProcessResponses readAllByDashboardId(long dashboardId) {
+    public ProcessResponses readAllByDashboardId(
+            long dashboardId,
+            Double minScore,
+            Double maxScore,
+            String evaluationStatus,
+            String sortByCreatedAt,
+            String sortByScore
+    ) {
         ApplyForm applyForm = applyFormService.findByDashboardId(dashboardId);
         List<Process> processes = processService.findAllByDashboard(dashboardId);
-        List<ApplicantCard> applicantCards = applicantService.findApplicantCards(processes);
+
+        List<ApplicantCard> applicantCards = applicantService.findApplicantCards(
+                processes, minScore, maxScore, evaluationStatus, sortByCreatedAt, sortByScore);
 
         List<ProcessResponse> processResponses = processes.stream()
                 .map(process -> toProcessResponse(process, applicantCards))

--- a/backend/src/main/java/com/cruru/process/service/ProcessService.java
+++ b/backend/src/main/java/com/cruru/process/service/ProcessService.java
@@ -93,6 +93,11 @@ public class ProcessService {
                 .orElseThrow(ProcessNotFoundException::new);
     }
 
+    public Process findByIdFetchingMember(Long processId) {
+        return processRepository.findByIdFetchingMember(processId)
+                .orElseThrow(ProcessNotFoundException::new);
+    }
+
     private boolean changeExists(ProcessUpdateRequest request, Process process) {
         return !(request.name().equals(process.getName()) && request.description().equals(process.getDescription()));
     }
@@ -116,5 +121,10 @@ public class ProcessService {
         if (applicantCount > ZERO) {
             throw new ProcessDeleteRemainingApplicantException();
         }
+    }
+
+    @Transactional
+    public void deleteAllInBatch(List<Process> processes) {
+        processRepository.deleteAllInBatch(processes);
     }
 }

--- a/backend/src/main/java/com/cruru/question/domain/repository/AnswerRepository.java
+++ b/backend/src/main/java/com/cruru/question/domain/repository/AnswerRepository.java
@@ -3,12 +3,25 @@ package com.cruru.question.domain.repository;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.question.domain.Answer;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
+    @EntityGraph(attributePaths = {"applicant.process.dashboard.club.member"})
+    @Query("SELECT a FROM Answer a WHERE a.id = :id")
+    Optional<Answer> findByIdFetchingMember(long id);
+
     @Query("SELECT a FROM Answer a JOIN FETCH a.question WHERE a.applicant = :applicant")
     List<Answer> findAllByApplicantWithQuestions(@Param("applicant") Applicant applicant);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM Answer a WHERE a.applicant IN :applicants")
+    void deleteAllByApplicants(@Param("applicants") List<Applicant> applicants);
 }

--- a/backend/src/main/java/com/cruru/question/domain/repository/ChoiceRepository.java
+++ b/backend/src/main/java/com/cruru/question/domain/repository/ChoiceRepository.java
@@ -3,9 +3,16 @@ package com.cruru.question.domain.repository;
 import com.cruru.question.domain.Choice;
 import com.cruru.question.domain.Question;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChoiceRepository extends JpaRepository<Choice, Long> {
+
+    @EntityGraph(attributePaths = {"question.applyForm.dashboard.club.member"})
+    @Query("SELECT c FROM Choice c WHERE c.id = :id")
+    Optional<Choice> findByIdFetchingMember(long id);
 
     List<Choice> findAllByQuestion(Question question);
 

--- a/backend/src/main/java/com/cruru/question/domain/repository/QuestionRepository.java
+++ b/backend/src/main/java/com/cruru/question/domain/repository/QuestionRepository.java
@@ -3,9 +3,16 @@ package com.cruru.question.domain.repository;
 import com.cruru.applyform.domain.ApplyForm;
 import com.cruru.question.domain.Question;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    @EntityGraph(attributePaths = {"applyForm.dashboard.club.member"})
+    @Query("SELECT q FROM Question q WHERE q.id = :id")
+    Optional<Question> findByIdFetchingMember(long id);
 
     List<Question> findAllByApplyForm(ApplyForm applyForm);
 }

--- a/backend/src/main/java/com/cruru/question/service/AnswerService.java
+++ b/backend/src/main/java/com/cruru/question/service/AnswerService.java
@@ -65,4 +65,9 @@ public class AnswerService {
         String mergedContent = existing.answer() + DELIMITER + newResponse.answer();
         return new AnswerResponse(existing.sequence(), existing.question(), mergedContent);
     }
+
+    @Transactional
+    public void deleteAllByApplicants(List<Applicant> applicants) {
+        answerRepository.deleteAllByApplicants(applicants);
+    }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,9 +23,11 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+        max_fetch_depth: 15
     hibernate:
       ddl-auto: create-drop
     defer-datasource-initialization: false
+    open-in-view: false
   mail:
     host: smtp.gmail.com
     port: 587
@@ -90,9 +92,11 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+        max_fetch_depth: 15
     hibernate:
       ddl-auto: ${DDL_AUTO}
     defer-datasource-initialization: false
+    open-in-view: false
   mail:
     host: smtp.gmail.com
     port: 587
@@ -174,9 +178,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+        max_fetch_depth: 15
     hibernate:
       ddl-auto: ${DDL_AUTO}
     defer-datasource-initialization: false
+    open-in-view: false
   mail:
     host: smtp.gmail.com
     port: 587
@@ -257,9 +263,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+        max_fetch_depth: 15
     hibernate:
       ddl-auto: ${DDL_AUTO}
     defer-datasource-initialization: false
+    open-in-view: false
   mail:
     host: smtp.gmail.com
     port: 587

--- a/backend/src/test/java/com/cruru/applicant/controller/ApplicantControllerTest.java
+++ b/backend/src/test/java/com/cruru/applicant/controller/ApplicantControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.restdocs.restassured.RestAssuredRestDocumentat
 
 import com.cruru.applicant.controller.request.ApplicantMoveRequest;
 import com.cruru.applicant.controller.request.ApplicantUpdateRequest;
+import com.cruru.applicant.controller.request.ApplicantsRejectRequest;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.applyform.domain.ApplyForm;
@@ -365,5 +366,131 @@ class ApplicantControllerTest extends ControllerTest {
                 ))
                 .when().patch("/v1/applicants/{applicantId}", invalidApplicantId)
                 .then().log().all().statusCode(404);
+    }
+
+    @DisplayName("모든 지원자를 불합격시키는 데 성공하면 200을 응답한다.")
+    @Test
+    void rejectAll() {
+        // given
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingRush());
+        ApplicantsRejectRequest request = new ApplicantsRejectRequest(List.of(applicant1.getId(), applicant2.getId()));
+
+        // when&then
+        RestAssured.given(spec).log().all()
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .filter(document(
+                        "applicant/reject-all/",
+                        requestCookies(cookieWithName("token").description("사용자 토큰")),
+                        requestFields(fieldWithPath("applicantIds").description("불합격 시킬 지원자들의 id"))
+                ))
+                .when().patch("/v1/applicants/reject")
+                .then().log().all().statusCode(200);
+    }
+
+    @DisplayName("존재하지 않는 지원자 불합격 시, 404를 응답한다.")
+    @Test
+    void rejectAll_applicantNotFound() {
+        // given
+        ApplicantsRejectRequest request = new ApplicantsRejectRequest(List.of(-1L));
+
+        // when&then
+        RestAssured.given(spec).log().all()
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .filter(document(
+                        "applicant/reject-all-fail/applicant-not-found/",
+                        requestCookies(cookieWithName("token").description("사용자 토큰")),
+                        requestFields(fieldWithPath("applicantIds").description("존재하지 않는 지원자의 id"))
+                ))
+                .when().patch("/v1/applicants/reject")
+                .then().log().all().statusCode(404);
+    }
+
+    @DisplayName("불합격 한 지원자 불합격 시, 400를 응답한다.")
+    @Test
+    void rejectAll_alreadyReject() {
+        // given
+        Applicant applicant = applicantRepository.save(ApplicantFixture.rejectedRush());
+        ApplicantsRejectRequest request = new ApplicantsRejectRequest(List.of(applicant.getId()));
+
+        // when&then
+        RestAssured.given(spec).log().all()
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .filter(document(
+                        "applicant/reject-all-fail/already-rejected/",
+                        requestCookies(cookieWithName("token").description("사용자 토큰")),
+                        requestFields(fieldWithPath("applicantIds").description("이미 불합격한 지원자의 id"))
+                ))
+                .when().patch("/v1/applicants/reject")
+                .then().log().all().statusCode(400);
+    }
+
+    @DisplayName("모든 지원자를 불합격 해제시키는데 성공하면 200을 응답한다.")
+    @Test
+    void unrejectAll() {
+        // given
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.rejectedRush());
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.rejectedRush());
+        ApplicantsRejectRequest request = new ApplicantsRejectRequest(List.of(applicant1.getId(), applicant2.getId()));
+
+        // when&then
+        RestAssured.given(spec).log().all()
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .filter(document(
+                        "applicant/unreject-all/",
+                        requestCookies(cookieWithName("token").description("사용자 토큰")),
+                        requestFields(fieldWithPath("applicantIds").description("불합격 해제시킬 지원자들의 id"))
+                ))
+                .when().patch("/v1/applicants/unreject")
+                .then().log().all().statusCode(200);
+    }
+
+    @DisplayName("존재하지 않는 지원자 불합격 해제 시, 404를 응답한다.")
+    @Test
+    void unrejectAll_applicantNotFound() {
+        // given
+        ApplicantsRejectRequest request = new ApplicantsRejectRequest(List.of(-1L));
+
+        // when&then
+        RestAssured.given(spec).log().all()
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .filter(document(
+                        "applicant/unreject-all-fail/applicant-not-found/",
+                        requestCookies(cookieWithName("token").description("사용자 토큰")),
+                        requestFields(fieldWithPath("applicantIds").description("존재하지 않는 지원자의 id"))
+                ))
+                .when().patch("/v1/applicants/unreject")
+                .then().log().all().statusCode(404);
+    }
+
+    @DisplayName("불합격 한 지원자 불합격 해제 시, 400를 응답한다.")
+    @Test
+    void unrejectAll_alreadyUnreject() {
+        // given
+        Applicant applicant = applicantRepository.save(ApplicantFixture.pendingDobby());
+        ApplicantsRejectRequest request = new ApplicantsRejectRequest(List.of(applicant.getId()));
+
+        // when&then
+        RestAssured.given(spec).log().all()
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .filter(document(
+                        "applicant/unreject-all-fail/already-unrejected/",
+                        requestCookies(cookieWithName("token").description("사용자 토큰")),
+                        requestFields(fieldWithPath("applicantIds").description("불합격하지 않은 지원자의 id"))
+                ))
+                .when().patch("/v1/applicants/unreject")
+                .then().log().all().statusCode(400);
     }
 }

--- a/backend/src/test/java/com/cruru/applicant/domain/ApplicantSortOptionTest.java
+++ b/backend/src/test/java/com/cruru/applicant/domain/ApplicantSortOptionTest.java
@@ -1,0 +1,112 @@
+package com.cruru.applicant.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cruru.applicant.domain.dto.ApplicantCard;
+import com.cruru.util.fixture.ApplicantCardFixture;
+import com.cruru.util.fixture.DefaultFilterAndOrderFixture;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+
+@DisplayName("지원자 정렬 테스트")
+class ApplicantSortOptionTest {
+
+    @Nested
+    @DisplayName("지원자의 지원 날짜 정렬 테스트")
+    class getCreatedAtComparatorTest {
+
+        @DisplayName("지원자의 지원 날짜 기준으로 오름차순으로 정렬한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"ASC", "asc"})
+        void getCreatedAtComparator_asc(String sortByCreatedAt) {
+            // given
+            LocalDateTime createdAt1 = LocalDateTime.of(2024, 10, 2, 20, 0);
+            LocalDateTime createdAt2 = LocalDateTime.of(2024, 10, 3, 20, 0);
+            ApplicantCard applicantCard1 = ApplicantCardFixture.evaluatedApplicantCard(createdAt1);
+            ApplicantCard applicantCard2 = ApplicantCardFixture.evaluatedApplicantCard(createdAt2);
+            List<ApplicantCard> applicantCards = Arrays.asList(applicantCard2, applicantCard1);
+
+            // when
+            applicantCards.sort(ApplicantSortOption.getCombinedComparator(
+                    sortByCreatedAt,
+                    DefaultFilterAndOrderFixture.DEFAULT_SORT_BY_SCORE
+            ));
+
+            // then
+            assertThat(applicantCards).containsExactly(applicantCard1, applicantCard2);
+        }
+
+        @DisplayName("지원자의 지원 날짜 기준으로 내림차순으로 정렬한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"DESC", "desc"})
+        void getCreatedAtComparator_desc(String sortByCreatedAt) {
+            // given
+            LocalDateTime createdAt1 = LocalDateTime.of(2024, 10, 2, 20, 0);
+            LocalDateTime createdAt2 = LocalDateTime.of(2024, 10, 3, 20, 0);
+            ApplicantCard applicantCard1 = ApplicantCardFixture.evaluatedApplicantCard(createdAt1);
+            ApplicantCard applicantCard2 = ApplicantCardFixture.evaluatedApplicantCard(createdAt2);
+            List<ApplicantCard> applicantCards = Arrays.asList(applicantCard1, applicantCard2);
+
+            // when
+            applicantCards.sort(ApplicantSortOption.getCombinedComparator(
+                    sortByCreatedAt,
+                    DefaultFilterAndOrderFixture.DEFAULT_SORT_BY_SCORE
+
+            ));
+
+            // then
+            assertThat(applicantCards).containsExactly(applicantCard2, applicantCard1);
+        }
+    }
+
+    @Nested
+    @DisplayName("지원자의 평균 점수 정렬 테스트")
+    class getScoreComparatorTest {
+
+        @DisplayName("지원자의 평균 점수 기준으로 오름차순으로 정렬한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"ASC", "asc"})
+        void getScoreComparator_asc(String sortByCreatedAt) {
+            // given
+            LocalDateTime createdAt = LocalDateTime.of(2024, 10, 2, 20, 0);
+            ApplicantCard applicantCard1 = ApplicantCardFixture.evaluatedApplicantCard(createdAt);
+            ApplicantCard applicantCard2 = ApplicantCardFixture.evaluatedApplicantCard(createdAt);
+            List<ApplicantCard> applicantCards = Arrays.asList(applicantCard1, applicantCard2);
+
+            // when
+            applicantCards.sort(ApplicantSortOption.getCombinedComparator(
+                    DefaultFilterAndOrderFixture.DEFAULT_SORT_BY_CREATED_AT,
+                    sortByCreatedAt
+            ));
+
+            // then
+            assertThat(applicantCards).containsExactly(applicantCard2, applicantCard1);
+        }
+
+        @DisplayName("지원자의 평균 점수 기준으로 내림차순으로 정렬한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"DESC", "desc"})
+        void getScoreComparator_desc(String sortByCreatedAt) {
+            // given
+            LocalDateTime createdAt = LocalDateTime.of(2024, 10, 2, 20, 0);
+            ApplicantCard applicantCard1 = ApplicantCardFixture.evaluatedApplicantCard(createdAt);
+            ApplicantCard applicantCard2 = ApplicantCardFixture.evaluatedApplicantCard(createdAt);
+            List<ApplicantCard> applicantCards = Arrays.asList(applicantCard2, applicantCard1);
+
+            // when
+            applicantCards.sort(ApplicantSortOption.getCombinedComparator(
+                    DefaultFilterAndOrderFixture.DEFAULT_SORT_BY_CREATED_AT,
+                    sortByCreatedAt
+            ));
+
+            // then
+            assertThat(applicantCards).containsExactly(applicantCard1, applicantCard2);
+        }
+    }
+}

--- a/backend/src/test/java/com/cruru/applicant/domain/EvaluationStatusTest.java
+++ b/backend/src/test/java/com/cruru/applicant/domain/EvaluationStatusTest.java
@@ -1,0 +1,108 @@
+package com.cruru.applicant.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cruru.applicant.domain.dto.ApplicantCard;
+import com.cruru.util.fixture.ApplicantCardFixture;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("지원자 평가 상태 필터링 테스트")
+class EvaluationStatusTest {
+
+    @Nested
+    @DisplayName("ALL 상태 테스트")
+    class AllStatusTest {
+
+        private static Stream<Arguments> provideApplicantCardsForAllStatus() {
+            return Stream.of(
+                    Arguments.of(ApplicantCardFixture.evaluatedApplicantCard(), "ALL"),
+                    Arguments.of(ApplicantCardFixture.notEvaluatedApplicantCard(), "ALL"),
+                    Arguments.of(ApplicantCardFixture.evaluatedApplicantCard(), "all"),
+                    Arguments.of(ApplicantCardFixture.notEvaluatedApplicantCard(), "all")
+            );
+        }
+
+        @DisplayName("평가 상태가 ALL이면 항상 true를 반환한다.")
+        @ParameterizedTest
+        @MethodSource("provideApplicantCardsForAllStatus")
+        void matchesEvaluationStatus_all(ApplicantCard card, String evaluationStatus) {
+            // when
+            boolean actual = EvaluationStatus.matches(card, evaluationStatus);
+
+            // then
+            assertThat(actual).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("NOT_EVALUATED 상태 테스트")
+    class NotEvaluatedStatusTest {
+
+        @DisplayName("평가 상태가 NOT_EVALUATED일 때, 평가 수가 0이면 true를 반환한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"NOT_EVALUATED", "not_evaluated"})
+        void matchesEvaluationStatus_notEvaluated_true(String evaluationStatus) {
+            // given
+            ApplicantCard card = ApplicantCardFixture.notEvaluatedApplicantCard();
+
+            // when
+            boolean actual = EvaluationStatus.matches(card, evaluationStatus);
+
+            // then
+            assertThat(actual).isTrue();
+        }
+
+        @DisplayName("평가 상태가 NOT_EVALUATED일 때, 평가 수가 0보다 크면 false를 반환한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"NOT_EVALUATED", "not_evaluated"})
+        void matchesEvaluationStatus_notEvaluated_false(String evaluationStatus) {
+            // given
+            ApplicantCard card = ApplicantCardFixture.evaluatedApplicantCard();
+
+            // when
+            boolean actual = EvaluationStatus.matches(card, evaluationStatus);
+
+            // then
+            assertThat(actual).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("EVALUATED 상태 테스트")
+    class EvaluatedStatusTest {
+
+        @DisplayName("평가 상태가 EVALUATED일 때, 평가 수가 0보다 크면 true를 반환한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"EVALUATED", "evaluated"})
+        void matchesEvaluationStatus_evaluated_true(String evaluationStatus) {
+            // given
+            ApplicantCard card = ApplicantCardFixture.evaluatedApplicantCard();
+
+            // when
+            boolean actual = EvaluationStatus.matches(card, evaluationStatus);
+
+            // then
+            assertThat(actual).isTrue();
+        }
+
+        @DisplayName("평가 상태가 EVALUATED일 때, 평가 수가 0이면 false를 반환한다.")
+        @ParameterizedTest
+        @ValueSource(strings = {"EVALUATED", "evaluated"})
+        void matchesEvaluationStatus_evaluated_false(String evaluationStatus) {
+            // given
+            ApplicantCard card = ApplicantCardFixture.notEvaluatedApplicantCard();
+
+            // when
+            boolean actual = EvaluationStatus.matches(card, evaluationStatus);
+
+            // then
+            assertThat(actual).isFalse();
+        }
+    }
+}

--- a/backend/src/test/java/com/cruru/applicant/domain/repository/ApplicantRepositoryTest.java
+++ b/backend/src/test/java/com/cruru/applicant/domain/repository/ApplicantRepositoryTest.java
@@ -4,19 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.cruru.applicant.domain.Applicant;
-import com.cruru.dashboard.domain.Dashboard;
-import com.cruru.dashboard.domain.repository.DashboardRepository;
-import com.cruru.process.domain.Process;
-import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.applicant.domain.Evaluation;
 import com.cruru.applicant.domain.dto.ApplicantCard;
+import com.cruru.dashboard.domain.Dashboard;
+import com.cruru.dashboard.domain.repository.DashboardRepository;
 import com.cruru.process.domain.Process;
 import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.util.RepositoryTest;
 import com.cruru.util.fixture.ApplicantFixture;
 import com.cruru.util.fixture.DashboardFixture;
-import com.cruru.util.fixture.ProcessFixture;
-import java.util.List;
 import com.cruru.util.fixture.EvaluationFixture;
 import com.cruru.util.fixture.ProcessFixture;
 import java.util.List;
@@ -221,5 +217,32 @@ class ApplicantRepositoryTest extends RepositoryTest {
         // then
         assertThat(applicants).hasSize(3);
         assertThat(applicants).containsExactlyInAnyOrder(applicant1, applicant2, applicant3);
+    }
+
+    @DisplayName("지원자를 전부 불합격시킨다.")
+    @Test
+    void rejectAll() {
+        // given
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant3 = applicantRepository.save(ApplicantFixture.pendingDobby());
+
+        List<Long> applicantIds = List.of(applicant1.getId(), applicant2.getId(), applicant3.getId());
+
+        // when
+        applicantRepository.updateRejectedStatusForApplicants(applicantIds, true);
+
+        // then
+        Applicant foundApplicant1 = applicantRepository.findById(applicant1.getId())
+                .orElseThrow();
+        Applicant foundApplicant2 = applicantRepository.findById(applicant2.getId())
+                .orElseThrow();
+        Applicant foundApplicant3 = applicantRepository.findById(applicant3.getId())
+                .orElseThrow();
+        assertAll(
+                () -> assertThat(foundApplicant1.isRejected()).isTrue(),
+                () -> assertThat(foundApplicant2.isRejected()).isTrue(),
+                () -> assertThat(foundApplicant3.isRejected()).isTrue()
+        );
     }
 }

--- a/backend/src/test/java/com/cruru/applicant/domain/repository/EvaluationRepositoryTest.java
+++ b/backend/src/test/java/com/cruru/applicant/domain/repository/EvaluationRepositoryTest.java
@@ -3,8 +3,12 @@ package com.cruru.applicant.domain.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.cruru.applicant.domain.Evaluation;
+import com.cruru.process.domain.Process;
+import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.util.RepositoryTest;
 import com.cruru.util.fixture.EvaluationFixture;
+import com.cruru.util.fixture.ProcessFixture;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +19,9 @@ class EvaluationRepositoryTest extends RepositoryTest {
 
     @Autowired
     private EvaluationRepository evaluationRepository;
+
+    @Autowired
+    private ProcessRepository processRepository;
 
     @BeforeEach
     void setUp() {
@@ -51,5 +58,26 @@ class EvaluationRepositoryTest extends RepositoryTest {
 
         //then
         assertThat(savedEvaluation1.getId() + 1).isEqualTo(savedEvaluation2.getId());
+    }
+
+    @DisplayName("입력된 프로세스 목록에 해당하는 평가들을 삭제한다.")
+    @Test
+    void deleteAllByProcesses() {
+        // given
+        com.cruru.process.domain.Process process1 = processRepository.save(ProcessFixture.applyType());
+        com.cruru.process.domain.Process process2 = processRepository.save(ProcessFixture.interview(null));
+        com.cruru.process.domain.Process process3 = processRepository.save(ProcessFixture.approveType());
+        List<Process> processes = List.of(process1, process2);
+
+        Evaluation evaluation1 = evaluationRepository.save(EvaluationFixture.fivePoints(process1, null));
+        Evaluation evaluation2 = evaluationRepository.save(EvaluationFixture.fivePoints(process2, null));
+        Evaluation evaluation3 = evaluationRepository.save(EvaluationFixture.fivePoints(process3, null));
+
+        // when
+        evaluationRepository.deleteAllByProcesses(processes);
+
+        // then
+        assertThat(evaluationRepository.findAll()).contains(evaluation3)
+                .doesNotContain(evaluation1, evaluation2);
     }
 }

--- a/backend/src/test/java/com/cruru/applicant/facade/ApplicantFacadeTest.java
+++ b/backend/src/test/java/com/cruru/applicant/facade/ApplicantFacadeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.cruru.applicant.controller.request.ApplicantMoveRequest;
 import com.cruru.applicant.controller.request.ApplicantUpdateRequest;
+import com.cruru.applicant.controller.request.ApplicantsRejectRequest;
 import com.cruru.applicant.controller.response.ApplicantAnswerResponses;
 import com.cruru.applicant.controller.response.ApplicantBasicResponse;
 import com.cruru.applicant.controller.response.ApplicantResponse;
@@ -189,5 +190,50 @@ class ApplicantFacadeTest extends ServiceTest {
         // then
         Applicant unrejectedApplicant = applicantRepository.findById(applicant.getId()).get();
         assertThat(unrejectedApplicant.isNotRejected()).isTrue();
+    }
+
+    @DisplayName("모든 지원자를 불합격시킨다.")
+    @Test
+    void rejectAll() {
+        // given
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingRush());
+        ApplicantsRejectRequest request = new ApplicantsRejectRequest(List.of(applicant1.getId(), applicant2.getId()));
+
+        // when
+        applicantFacade.reject(request);
+
+        // then
+        Applicant foundApplicant1 = applicantRepository.findById(applicant1.getId())
+                .orElseThrow();
+        Applicant foundApplicant2 = applicantRepository.findById(applicant2.getId())
+                .orElseThrow();
+        assertAll(
+                () -> assertThat(foundApplicant1.isRejected()).isTrue(),
+                () -> assertThat(foundApplicant2.isRejected()).isTrue()
+        );
+    }
+
+    @DisplayName("모든 지원자 불합격 해제시킨다.")
+    @Test
+    void unrejectAll() {
+        // given
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.rejectedRush());
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.rejectedRush());
+
+        ApplicantsRejectRequest request = new ApplicantsRejectRequest(List.of(applicant1.getId(), applicant2.getId()));
+
+        // when
+        applicantFacade.unreject(request);
+
+        // then
+        Applicant foundApplicant1 = applicantRepository.findById(applicant1.getId())
+                .orElseThrow();
+        Applicant foundApplicant2 = applicantRepository.findById(applicant2.getId())
+                .orElseThrow();
+        assertAll(
+                () -> assertThat(foundApplicant1.isRejected()).isFalse(),
+                () -> assertThat(foundApplicant2.isRejected()).isFalse()
+        );
     }
 }

--- a/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
+++ b/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
@@ -8,7 +8,9 @@ import com.cruru.applicant.controller.request.ApplicantCreateRequest;
 import com.cruru.applicant.controller.request.ApplicantMoveRequest;
 import com.cruru.applicant.controller.request.ApplicantUpdateRequest;
 import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.domain.dto.ApplicantCard;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
+import com.cruru.applicant.domain.repository.EvaluationRepository;
 import com.cruru.applicant.exception.ApplicantNotFoundException;
 import com.cruru.applicant.exception.badrequest.ApplicantRejectException;
 import com.cruru.applicant.exception.badrequest.ApplicantUnrejectException;
@@ -19,6 +21,8 @@ import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.util.ServiceTest;
 import com.cruru.util.fixture.ApplicantFixture;
 import com.cruru.util.fixture.DashboardFixture;
+import com.cruru.util.fixture.DefaultFilterAndOrderFixture;
+import com.cruru.util.fixture.EvaluationFixture;
 import com.cruru.util.fixture.ProcessFixture;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -40,6 +44,9 @@ class ApplicantServiceTest extends ServiceTest {
 
     @Autowired
     private DashboardRepository dashboardRepository;
+
+    @Autowired
+    private EvaluationRepository evaluationRepository;
 
     @Autowired
     private EntityManager entityManager;
@@ -81,6 +88,39 @@ class ApplicantServiceTest extends ServiceTest {
 
         // then
         assertThat(applicantsInProcess).containsExactlyElementsOf(applicants);
+    }
+
+    @DisplayName("프로세스 내의 모든 지원자를 필터링 및 정렬하여 조회한다.")
+    @Test
+    void findAllByProcess_filterAndOrder() {
+        // given
+        Process process1 = processRepository.save(ProcessFixture.applyType());
+        Process process2 = processRepository.save(ProcessFixture.applyType());
+        List<Process> processes = List.of(process1, process2);
+
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby(process1));
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingRush(process1));
+        applicantRepository.save(ApplicantFixture.pendingDobby(process2));
+
+        evaluationRepository.save(EvaluationFixture.fivePoints(process1, applicant1));
+        evaluationRepository.save(EvaluationFixture.fourPoints(process1, applicant2));
+
+        String evaluationStatus = "EVALUATED";
+
+        // when
+        List<ApplicantCard> applicantCards = applicantService.findApplicantCards(
+                processes,
+                DefaultFilterAndOrderFixture.DEFAULT_MIN_SCORE,
+                DefaultFilterAndOrderFixture.DEFAULT_MAX_SCORE,
+                evaluationStatus,
+                DefaultFilterAndOrderFixture.DEFAULT_SORT_BY_CREATED_AT,
+                DefaultFilterAndOrderFixture.DEFAULT_SORT_BY_SCORE
+        );
+
+        // then
+        assertThat(applicantCards).hasSize(2);
+        assertThat(applicantCards.get(0).id()).isEqualTo(applicant2.getId());
+        assertThat(applicantCards.get(1).id()).isEqualTo(applicant1.getId());
     }
 
     @DisplayName("id에 해당하는 지원자가 존재하지 않으면 Not Found 예외가 발생한다.")
@@ -198,5 +238,22 @@ class ApplicantServiceTest extends ServiceTest {
         Long applicantId = applicant.getId();
         assertThatThrownBy(() -> applicantService.unreject(applicantId))
                 .isInstanceOf(ApplicantUnrejectException.class);
+    }
+
+    @DisplayName("입력된 지원자들을 삭제한다.")
+    @Test
+    void deleteAllInBatch() {
+        // given
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant3 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        List<Applicant> applicants = List.of(applicant1, applicant2);
+
+        // when
+        applicantService.deleteAllInBatch(applicants);
+
+        // then
+        assertThat(applicantRepository.findAll()).contains(applicant3)
+                .doesNotContain(applicant1, applicant2);
     }
 }

--- a/backend/src/test/java/com/cruru/applicant/service/EvaluationServiceTest.java
+++ b/backend/src/test/java/com/cruru/applicant/service/EvaluationServiceTest.java
@@ -111,4 +111,44 @@ class EvaluationServiceTest extends ServiceTest {
                 () -> assertThat(updatedEvaluation.get().getContent()).isEqualTo(content)
         );
     }
+
+    @DisplayName("입력된 프로세스에 해당하는 평가들을 삭제한다.")
+    @Test
+    void deleteByProcess() {
+        // given
+        Process process1 = processRepository.save(ProcessFixture.applyType());
+        Process process2 = processRepository.save(ProcessFixture.approveType());
+
+        Evaluation evaluation1 = evaluationRepository.save(EvaluationFixture.fivePoints(process1, null));
+        Evaluation evaluation2 = evaluationRepository.save(EvaluationFixture.fivePoints(process1, null));
+        Evaluation evaluation3 = evaluationRepository.save(EvaluationFixture.fivePoints(process2, null));
+
+        // when
+        evaluationService.deleteByProcess(process1.getId());
+
+        // then
+        assertThat(evaluationRepository.findAll()).contains(evaluation3)
+                .doesNotContain(evaluation1, evaluation2);
+    }
+
+    @DisplayName("입력된 프로세스 목록에 해당하는 평가들을 삭제한다.")
+    @Test
+    void deleteAllByProcesses() {
+        // given
+        Process process1 = processRepository.save(ProcessFixture.applyType());
+        Process process2 = processRepository.save(ProcessFixture.interview(null));
+        Process process3 = processRepository.save(ProcessFixture.approveType());
+        List<Process> processes = List.of(process1, process2);
+
+        Evaluation evaluation1 = evaluationRepository.save(EvaluationFixture.fivePoints(process1, null));
+        Evaluation evaluation2 = evaluationRepository.save(EvaluationFixture.fivePoints(process2, null));
+        Evaluation evaluation3 = evaluationRepository.save(EvaluationFixture.fivePoints(process3, null));
+
+        // when
+        evaluationService.deleteAllByProcesses(processes);
+
+        // then
+        assertThat(evaluationRepository.findAll()).contains(evaluation3)
+                .doesNotContain(evaluation1, evaluation2);
+    }
 }

--- a/backend/src/test/java/com/cruru/applyform/facade/ApplyFormFacadeTest.java
+++ b/backend/src/test/java/com/cruru/applyform/facade/ApplyFormFacadeTest.java
@@ -23,7 +23,6 @@ import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.question.controller.response.QuestionResponse;
 import com.cruru.question.domain.Question;
 import com.cruru.question.domain.repository.AnswerRepository;
-import com.cruru.question.domain.repository.ChoiceRepository;
 import com.cruru.question.domain.repository.QuestionRepository;
 import com.cruru.util.ServiceTest;
 import com.cruru.util.fixture.ApplyFormFixture;

--- a/backend/src/test/java/com/cruru/applyform/service/ApplyFormServiceTest.java
+++ b/backend/src/test/java/com/cruru/applyform/service/ApplyFormServiceTest.java
@@ -110,14 +110,15 @@ class ApplyFormServiceTest extends ServiceTest {
 
     @DisplayName("지원서 폼 조회 시, 지원서 폼이 존재하지 않을 경우 예외가 발생한다.")
     @Test
-    void findById_invalidApplyForm() {
+    void findById_FetchingMember_invalidApplyForm() {
         // given
         processRepository.save(ProcessFixture.applyType(dashboard));
         ApplyForm applyForm = applyFormRepository.save(ApplyFormFixture.frontend(dashboard));
         questionRepository.save(QuestionFixture.shortAnswerType(applyForm));
 
         // when&then
-        assertThatThrownBy(() -> applyFormService.findById(-1L)).isInstanceOf(ApplyFormNotFoundException.class);
+        assertThatThrownBy(() -> applyFormService.findById(-1L))
+                .isInstanceOf(ApplyFormNotFoundException.class);
     }
 
     @DisplayName("대시보드 ID로 지원폼을 조회한다.")
@@ -156,5 +157,18 @@ class ApplyFormServiceTest extends ServiceTest {
                 () -> assertThat(actual.getStartDate()).isEqualTo(toChangeStartDate),
                 () -> assertThat(actual.getEndDate()).isEqualTo(toChangeEndDate)
         );
+    }
+
+    @DisplayName("해당 지원폼을 삭제한다.")
+    @Test
+    void delete() {
+        // given
+        ApplyForm applyForm = applyFormRepository.save(ApplyFormFixture.backend(dashboard));
+
+        // when
+        applyFormService.delete(applyForm);
+
+        // then
+        assertThat(applyFormRepository.findAll()).doesNotContain(applyForm);
     }
 }

--- a/backend/src/test/java/com/cruru/dashboard/service/DashboardServiceTest.java
+++ b/backend/src/test/java/com/cruru/dashboard/service/DashboardServiceTest.java
@@ -91,4 +91,17 @@ class DashboardServiceTest extends ServiceTest {
                 new DashboardApplyFormDto(frontendDashboard, frontendApplyform)
         );
     }
+
+    @DisplayName("해당 ID의 대시보드를 삭제한다.")
+    @Test
+    void deleteById() {
+        // given
+        Dashboard backendDashboard = dashboardRepository.save(DashboardFixture.backend());
+
+        // when
+        dashboardService.deleteById(backendDashboard.getId());
+
+        // then
+        assertThat(dashboardRepository.findAll()).doesNotContain(backendDashboard);
+    }
 }

--- a/backend/src/test/java/com/cruru/email/domain/repository/EmailRepositoryTest.java
+++ b/backend/src/test/java/com/cruru/email/domain/repository/EmailRepositoryTest.java
@@ -2,9 +2,13 @@ package com.cruru.email.domain.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.email.domain.Email;
 import com.cruru.util.RepositoryTest;
+import com.cruru.util.fixture.ApplicantFixture;
 import com.cruru.util.fixture.EmailFixture;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +19,9 @@ class EmailRepositoryTest extends RepositoryTest {
 
     @Autowired
     private EmailRepository emailRepository;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
 
     @BeforeEach
     void setUp() {
@@ -57,5 +64,26 @@ class EmailRepositoryTest extends RepositoryTest {
 
         //then
         assertThat(savedEmail1.getId() + 1).isEqualTo(savedEmail2.getId());
+    }
+
+    @DisplayName("대상 지원자 목록에 따라 모두 삭제한다.")
+    @Test
+    void deleteAllByTos() {
+        // given
+        Applicant to1 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant to2 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant to3 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        List<Applicant> tos = List.of(to1, to2);
+
+        Email email1 = emailRepository.save(EmailFixture.rejectEmail(null, to1));
+        Email email2 = emailRepository.save(EmailFixture.rejectEmail(null, to2));
+        Email email3 = emailRepository.save(EmailFixture.rejectEmail(null, to3));
+
+        // when
+        emailRepository.deleteAllByTos(tos);
+
+        // then
+        assertThat(emailRepository.findAll()).contains(email3)
+                .doesNotContain(email1, email2);
     }
 }

--- a/backend/src/test/java/com/cruru/email/service/EmailServiceTest.java
+++ b/backend/src/test/java/com/cruru/email/service/EmailServiceTest.java
@@ -3,9 +3,12 @@ package com.cruru.email.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.email.domain.Email;
 import com.cruru.email.domain.repository.EmailRepository;
 import com.cruru.util.ServiceTest;
+import com.cruru.util.fixture.ApplicantFixture;
 import com.cruru.util.fixture.EmailFixture;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +23,9 @@ class EmailServiceTest extends ServiceTest {
 
     @Autowired
     private EmailService emailService;
+
+    @Autowired
+    private ApplicantRepository applicantRepository;
 
     @DisplayName("발송 내역을 저장한다.")
     @Test
@@ -39,5 +45,26 @@ class EmailServiceTest extends ServiceTest {
                 () -> assertThat(actual.getSubject()).isEqualTo(subject),
                 () -> assertThat(actual.getContent()).isEqualTo(content)
         );
+    }
+
+    @DisplayName("대상 지원자 목록에 따라 모두 삭제한다.")
+    @Test
+    void deleteAllByTos() {
+        // given
+        Applicant to1 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant to2 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant to3 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        List<Applicant> tos = List.of(to1, to2);
+
+        Email email1 = emailRepository.save(EmailFixture.rejectEmail(null, to1));
+        Email email2 = emailRepository.save(EmailFixture.rejectEmail(null, to2));
+        Email email3 = emailRepository.save(EmailFixture.rejectEmail(null, to3));
+
+        // when
+        emailService.deleteAllByTos(tos);
+
+        // then
+        assertThat(emailRepository.findAll()).contains(email3)
+                .doesNotContain(email1, email2);
     }
 }

--- a/backend/src/test/java/com/cruru/process/facade/ProcessFacadeTest.java
+++ b/backend/src/test/java/com/cruru/process/facade/ProcessFacadeTest.java
@@ -18,6 +18,7 @@ import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.util.ServiceTest;
 import com.cruru.util.fixture.ApplicantFixture;
 import com.cruru.util.fixture.ApplyFormFixture;
+import com.cruru.util.fixture.DefaultFilterAndOrderFixture;
 import com.cruru.util.fixture.EvaluationFixture;
 import com.cruru.util.fixture.ProcessFixture;
 import java.util.Comparator;
@@ -73,28 +74,35 @@ class ProcessFacadeTest extends ServiceTest {
     void readAllByDashboardId() {
         // given
         applyFormRepository.save(ApplyFormFixture.backend(defaultDashboard));
-        Process process = processRepository.save(ProcessFixture.applyType(defaultDashboard));
-        Process process1 = processRepository.save(ProcessFixture.interview(defaultDashboard));
-        Applicant applicant = applicantRepository.save(ApplicantFixture.pendingDobby(process));
-        Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby(process));
-        List<Evaluation> evaluations = List.of(
-                EvaluationFixture.fivePoints(process, applicant),
-                EvaluationFixture.fourPoints(process, applicant),
-                EvaluationFixture.fourPoints(process, applicant),
-                EvaluationFixture.fourPoints(process, applicant)
-        );
-        evaluationRepository.saveAll(evaluations);
-
+        Process process1 = processRepository.save(ProcessFixture.applyType(defaultDashboard));
+        Process process2 = processRepository.save(ProcessFixture.interview(defaultDashboard));
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby(process1));
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingDobby(process1));
         List<Evaluation> evaluations1 = List.of(
                 EvaluationFixture.fivePoints(process1, applicant1),
-                EvaluationFixture.fivePoints(process1, applicant1),
-                EvaluationFixture.fivePoints(process1, applicant1),
+                EvaluationFixture.fourPoints(process1, applicant1),
+                EvaluationFixture.fourPoints(process1, applicant1),
                 EvaluationFixture.fourPoints(process1, applicant1)
         );
         evaluationRepository.saveAll(evaluations1);
 
+        List<Evaluation> evaluations2 = List.of(
+                EvaluationFixture.fivePoints(process2, applicant2),
+                EvaluationFixture.fivePoints(process2, applicant2),
+                EvaluationFixture.fivePoints(process2, applicant2),
+                EvaluationFixture.fourPoints(process2, applicant2)
+        );
+        evaluationRepository.saveAll(evaluations2);
+
         // when
-        ProcessResponses processResponses = processFacade.readAllByDashboardId(defaultDashboard.getId());
+        ProcessResponses processResponses = processFacade.readAllByDashboardId(
+                defaultDashboard.getId(),
+                DefaultFilterAndOrderFixture.DEFAULT_MIN_SCORE,
+                DefaultFilterAndOrderFixture.DEFAULT_MAX_SCORE,
+                DefaultFilterAndOrderFixture.DEFAULT_EVALUATION_STATUS,
+                DefaultFilterAndOrderFixture.DEFAULT_SORT_BY_CREATED_AT,
+                DefaultFilterAndOrderFixture.DEFAULT_SORT_BY_SCORE
+        );
 
         // then
         ProcessResponse firstProcessResponse = processResponses.processResponses().get(0);
@@ -102,10 +110,10 @@ class ProcessFacadeTest extends ServiceTest {
         ApplicantCardResponse applicantCardResponse = firstProcessResponse.applicantCardResponses().get(0);
         assertAll(
                 () -> assertThat(processResponses.processResponses()).hasSize(2),
-                () -> assertThat(processId).isEqualTo(process.getId()),
-                () -> assertThat(applicantCardResponse.id()).isEqualTo(applicant.getId()),
-                () -> assertThat(applicantCardResponse.evaluationCount()).isEqualTo(evaluations.size()),
-                () -> assertThat(applicantCardResponse.averageScore()).isEqualTo(4.25)
+                () -> assertThat(processId).isEqualTo(process1.getId()),
+                () -> assertThat(applicantCardResponse.id()).isEqualTo(applicant2.getId()),
+                () -> assertThat(applicantCardResponse.evaluationCount()).isEqualTo(evaluations1.size()),
+                () -> assertThat(applicantCardResponse.averageScore()).isEqualTo(4.75)
         );
     }
 

--- a/backend/src/test/java/com/cruru/process/service/ProcessServiceTest.java
+++ b/backend/src/test/java/com/cruru/process/service/ProcessServiceTest.java
@@ -172,4 +172,21 @@ class ProcessServiceTest extends ServiceTest {
         assertThatThrownBy(() -> processService.delete(processId))
                 .isInstanceOf(ProcessDeleteRemainingApplicantException.class);
     }
+
+    @DisplayName("입력된 프로세스들을 삭제한다.")
+    @Test
+    void deleteAllInBatch() {
+        // given
+        Process process1 = processRepository.save(ProcessFixture.applyType());
+        Process process2 = processRepository.save(ProcessFixture.interview(null));
+        Process process3 = processRepository.save(ProcessFixture.approveType());
+        List<Process> processes = List.of(process1, process2);
+
+        // when
+        processService.deleteAllInBatch(processes);
+
+        // then
+        assertThat(processRepository.findAll()).contains(process3)
+                .doesNotContain(process1, process2);
+    }
 }

--- a/backend/src/test/java/com/cruru/question/domain/repository/AnswerRepositoryTest.java
+++ b/backend/src/test/java/com/cruru/question/domain/repository/AnswerRepositoryTest.java
@@ -93,4 +93,27 @@ class AnswerRepositoryTest extends RepositoryTest {
                 () -> assertThat(actualAnswer.getApplicant()).isEqualTo(applicant)
         );
     }
+
+    @DisplayName("지원자 목록에 따라 모두 삭제한다.")
+    @Test
+    void deleteAllByApplicants() {
+        // given
+        Question question = questionRepository.save(QuestionFixture.shortAnswerType(null));
+
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant3 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        List<Applicant> applicants = List.of(applicant1, applicant2);
+
+        Answer answer1 = answerRepository.save(AnswerFixture.first(question, applicant1));
+        Answer answer2 = answerRepository.save(AnswerFixture.second(question, applicant2));
+        Answer answer3 = answerRepository.save(AnswerFixture.second(question, applicant3));
+
+        // when
+        answerRepository.deleteAllByApplicants(applicants);
+
+        // then
+        assertThat(answerRepository.findAll()).contains(answer3)
+                .doesNotContain(answer1, answer2);
+    }
 }

--- a/backend/src/test/java/com/cruru/question/service/AnswerServiceTest.java
+++ b/backend/src/test/java/com/cruru/question/service/AnswerServiceTest.java
@@ -166,4 +166,27 @@ class AnswerServiceTest extends ServiceTest {
                 () -> assertThat(actualAnswerResponses.get(0).answer()).contains(expectedAnswer3.getContent())
         );
     }
+
+    @DisplayName("지원자 목록에 따라 모두 삭제한다.")
+    @Test
+    void deleteAllByApplicants() {
+        // given
+        Question question = questionRepository.save(QuestionFixture.shortAnswerType(null));
+
+        Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        Applicant applicant3 = applicantRepository.save(ApplicantFixture.pendingDobby());
+        List<Applicant> applicants = List.of(applicant1, applicant2);
+
+        Answer answer1 = answerRepository.save(AnswerFixture.first(question, applicant1));
+        Answer answer2 = answerRepository.save(AnswerFixture.second(question, applicant2));
+        Answer answer3 = answerRepository.save(AnswerFixture.second(question, applicant3));
+
+        // when
+        answerService.deleteAllByApplicants(applicants);
+
+        // then
+        assertThat(answerRepository.findAll()).contains(answer3)
+                .doesNotContain(answer1, answer2);
+    }
 }

--- a/backend/src/test/java/com/cruru/util/fixture/ApplicantCardFixture.java
+++ b/backend/src/test/java/com/cruru/util/fixture/ApplicantCardFixture.java
@@ -1,0 +1,27 @@
+package com.cruru.util.fixture;
+
+import com.cruru.applicant.domain.dto.ApplicantCard;
+import java.time.LocalDateTime;
+
+public class ApplicantCardFixture {
+
+    private ApplicantCardFixture() {
+
+    }
+
+    public static ApplicantCard evaluatedApplicantCard() {
+        return new ApplicantCard(1L, "냥인", null, false, 5, 3.00, 1L);
+    }
+
+    public static ApplicantCard evaluatedApplicantCard(LocalDateTime createdAt) {
+        return new ApplicantCard(1L, "냥인", createdAt, false, 5, 3.00, 1L);
+    }
+
+    public static ApplicantCard notEvaluatedApplicantCard() {
+        return new ApplicantCard(2L, "렛서", null, false, 0, 0.00, 1L);
+    }
+
+    public static ApplicantCard notEvaluatedApplicantCard(LocalDateTime createdAt) {
+        return new ApplicantCard(2L, "렛서", createdAt, false, 0, 0.00, 1L);
+    }
+}

--- a/backend/src/test/java/com/cruru/util/fixture/DefaultFilterAndOrderFixture.java
+++ b/backend/src/test/java/com/cruru/util/fixture/DefaultFilterAndOrderFixture.java
@@ -1,0 +1,14 @@
+package com.cruru.util.fixture;
+
+public class DefaultFilterAndOrderFixture {
+
+    private DefaultFilterAndOrderFixture() {
+
+    }
+
+    public static final Double DEFAULT_MIN_SCORE = 0.00;
+    public static final Double DEFAULT_MAX_SCORE = 5.00;
+    public static final String DEFAULT_EVALUATION_STATUS = "ALL";
+    public static final String DEFAULT_SORT_BY_CREATED_AT = "DESC";
+    public static final String DEFAULT_SORT_BY_SCORE = "DESC";
+}

--- a/backend/src/test/java/com/cruru/util/fixture/EmailFixture.java
+++ b/backend/src/test/java/com/cruru/util/fixture/EmailFixture.java
@@ -1,5 +1,7 @@
 package com.cruru.util.fixture;
 
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.club.domain.Club;
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.email.domain.Email;
 
@@ -27,6 +29,16 @@ public class EmailFixture {
         return new Email(
                 null,
                 null,
+                SUBJECT,
+                REJECT_CONTENT,
+                true
+        );
+    }
+
+    public static Email rejectEmail(Club from, Applicant to) {
+        return new Email(
+                from,
+                to,
                 SUBJECT,
                 REJECT_CONTENT,
                 true

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -18,9 +18,11 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+        max_fetch_depth: 15
     hibernate:
       ddl-auto: create-drop
     defer-datasource-initialization: false
+    open-in-view: false
   mail:
     host: smtp.gmail.com
 


### PR DESCRIPTION
Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Co-authored-by: Kwoun Ki Ho <fingercut3822@gmail.com>

feat-be: 프로세스 목록 조회 API  필터링 및 정렬 구현 (#756)

Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Co-authored-by: cutehumanS2 <oddpinkjadeite@gmail.com>

feat-be: 다중 불합격자 해제 기능 구현 (#759)

Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Co-authored-by: Kwoun Ki Ho <fingercut3822@gmail.com>

feat-be: 대시보드 삭제 api 구현 (#749)

Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Co-authored-by: HyungHoKim00 <hkim1109@naver.com>

fix-be: 예외 처리 과정에서 NPE가 발생하지 않도록 수정  (#753)

feat-be: 다중 불합격자 기능 구현 (#751)

Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Co-authored-by: Kwoun Ki Ho <fingercut3822@gmail.com>

chore-be(Actions-Prod): 무중단 배포 설정 수정
