### PR TITLE
fix-be: applicantCard 조회 시 평가 점수와 갯수가 모든 프로세스에 대해 나오는 버그 수정

### DIFF
--- a/backend/src/main/java/com/cruru/applicant/domain/repository/ApplicantRepository.java
+++ b/backend/src/main/java/com/cruru/applicant/domain/repository/ApplicantRepository.java
@@ -24,11 +24,11 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     long countByProcess(Process process);
 
     @Query("""
-           SELECT new com.cruru.applicant.domain.dto.ApplicantCard( 
+           SELECT new com.cruru.applicant.domain.dto.ApplicantCard(
                a.id, a.name, a.createdDate, a.isRejected, COUNT(e), COALESCE(AVG(e.score), 0.00), a.process.id
            )
            FROM Applicant a
-           LEFT JOIN Evaluation e ON e.applicant = a
+           LEFT JOIN Evaluation e ON e.applicant = a AND e.process = a.process
            WHERE a.process IN :processes
            GROUP BY a.id, a.name, a.createdDate, a.isRejected, a.process.id
            """)
@@ -39,7 +39,7 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
                       a.id, a.name, a.createdDate, a.isRejected, COUNT(e), COALESCE(AVG(e.score), 0.00), a.process.id
                   )
                   FROM Applicant a
-                  LEFT JOIN Evaluation e ON e.applicant = a
+                  LEFT JOIN Evaluation e ON e.applicant = a AND e.process = a.process
                   WHERE a.process = :process
                   GROUP BY a.id, a.name, a.createdDate, a.isRejected
            """)

--- a/backend/src/main/java/com/cruru/config/DataSourceConfig.java
+++ b/backend/src/main/java/com/cruru/config/DataSourceConfig.java
@@ -44,20 +44,16 @@ public class DataSourceConfig {
     @Bean(name = WRITE_DATASOURCE)
     @ConfigurationProperties(prefix = "spring.datasource.write")
     public DataSource writeDataSource() {
-        HikariDataSource build = DataSourceBuilder.create()
+        return DataSourceBuilder.create()
                 .type(HikariDataSource.class)
                 .build();
-        build.setMaximumPoolSize(5);
-        return build;
     }
 
     @Bean(name = READ_DATASOURCE)
     @ConfigurationProperties(prefix = "spring.datasource.read")
     public DataSource readDataSource() {
-        HikariDataSource build = DataSourceBuilder.create()
+        return DataSourceBuilder.create()
                 .type(HikariDataSource.class)
                 .build();
-        build.setMaximumPoolSize(10);
-        return build;
     }
 }

--- a/backend/src/main/java/com/cruru/config/DataSourceConfig.java
+++ b/backend/src/main/java/com/cruru/config/DataSourceConfig.java
@@ -19,20 +19,11 @@ public class DataSourceConfig {
     private static final String WRITE_DATASOURCE = "writeDataSource";
     private static final String ROUTE_DATASOURCE = "routeDataSource";
 
-    @Bean(name = READ_DATASOURCE)
-    @ConfigurationProperties(prefix = "spring.datasource.read")
-    public DataSource readDataSource() {
-        return DataSourceBuilder.create()
-                .type(HikariDataSource.class)
-                .build();
-    }
-
-    @Bean(name = WRITE_DATASOURCE)
-    @ConfigurationProperties(prefix = "spring.datasource.write")
-    public DataSource writeDataSource() {
-        return DataSourceBuilder.create()
-                .type(HikariDataSource.class)
-                .build();
+    @Bean
+    @Primary
+    @DependsOn(ROUTE_DATASOURCE)
+    public DataSource defaultDataSource() {
+        return new LazyConnectionDataSourceProxy(routeDataSource());
     }
 
     @Bean(name = ROUTE_DATASOURCE)
@@ -50,10 +41,23 @@ public class DataSourceConfig {
         return dataSourceRouter;
     }
 
-    @Bean
-    @Primary
-    @DependsOn(ROUTE_DATASOURCE)
-    public DataSource defaultDataSource() {
-        return new LazyConnectionDataSourceProxy(routeDataSource());
+    @Bean(name = WRITE_DATASOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.write")
+    public DataSource writeDataSource() {
+        HikariDataSource build = DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+        build.setMaximumPoolSize(5);
+        return build;
+    }
+
+    @Bean(name = READ_DATASOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.read")
+    public DataSource readDataSource() {
+        HikariDataSource build = DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+        build.setMaximumPoolSize(10);
+        return build;
     }
 }

--- a/backend/src/test/java/com/cruru/applicant/domain/repository/ApplicantRepositoryTest.java
+++ b/backend/src/test/java/com/cruru/applicant/domain/repository/ApplicantRepositoryTest.java
@@ -78,31 +78,31 @@ class ApplicantRepositoryTest extends RepositoryTest {
     @Test
     void findApplicantCardsByProcesses() {
         // given
-        Process process = processRepository.save(ProcessFixture.applyType());
+        Process process1 = processRepository.save(ProcessFixture.applyType());
+        Process process2 = processRepository.save(ProcessFixture.interview(null));
 
-        Applicant applicant1 = ApplicantFixture.pendingDobby(process);
-        Applicant applicant2 = ApplicantFixture.pendingRush(process);
+        Applicant applicant1 = ApplicantFixture.pendingDobby(process1);
+        Applicant applicant2 = ApplicantFixture.pendingRush(process1);
         applicantRepository.saveAll(List.of(applicant1, applicant2));
 
         List<Evaluation> evaluations = List.of(
-                EvaluationFixture.fivePoints(process, applicant1),
-                EvaluationFixture.fivePoints(process, applicant1),
-                EvaluationFixture.fivePoints(process, applicant2)
+                EvaluationFixture.fourPoints(process1, applicant1),
+                EvaluationFixture.fivePoints(process2, applicant1),
+                EvaluationFixture.fivePoints(process1, applicant2)
         );
         evaluationRepository.saveAll(evaluations);
 
         // when
-        List<ApplicantCard> applicantCards = applicantRepository.findApplicantCardsByProcesses(List.of(process));
+        List<ApplicantCard> applicantCards = applicantRepository.findApplicantCardsByProcesses(List.of(process1));
 
         // then
         assertThat(applicantCards).hasSize(2);
-
         ApplicantCard applicantCard1 = applicantCards.get(0);
         assertAll(
                 () -> assertThat(applicantCard1.id()).isEqualTo(applicant1.getId()),
                 () -> assertThat(applicantCard1.name()).isEqualTo(applicant1.getName()),
-                () -> assertThat(applicantCard1.evaluationCount()).isEqualTo(2),
-                () -> assertThat(applicantCard1.averageScore()).isEqualTo(5.0)
+                () -> assertThat(applicantCard1.evaluationCount()).isEqualTo(1),
+                () -> assertThat(applicantCard1.averageScore()).isEqualTo(4.0)
         );
 
         ApplicantCard applicantCard2 = applicantCards.get(1);
@@ -140,39 +140,31 @@ class ApplicantRepositoryTest extends RepositoryTest {
     @Test
     void findApplicantCardsByProcess() {
         // given
-        Process process = processRepository.save(ProcessFixture.applyType());
+        Process process1 = processRepository.save(ProcessFixture.applyType());
+        Process process2 = processRepository.save(ProcessFixture.interview(null));
 
-        Applicant applicant1 = ApplicantFixture.pendingDobby(process);
-        Applicant applicant2 = ApplicantFixture.pendingRush(process);
+        Applicant applicant1 = ApplicantFixture.pendingDobby(process1);
+        Applicant applicant2 = ApplicantFixture.pendingRush(process2);
         applicantRepository.saveAll(List.of(applicant1, applicant2));
 
         List<Evaluation> evaluations = List.of(
-                EvaluationFixture.fivePoints(process, applicant1),
-                EvaluationFixture.fivePoints(process, applicant1),
-                EvaluationFixture.fivePoints(process, applicant2)
+                EvaluationFixture.fourPoints(process1, applicant1),
+                EvaluationFixture.fivePoints(process2, applicant1),
+                EvaluationFixture.fivePoints(process1, applicant2)
         );
         evaluationRepository.saveAll(evaluations);
 
         // when
-        List<ApplicantCard> applicantCards = applicantRepository.findApplicantCardsByProcess(process);
+        List<ApplicantCard> applicantCards = applicantRepository.findApplicantCardsByProcess(process1);
 
         // then
-        assertThat(applicantCards).hasSize(2);
-
-        ApplicantCard applicantCard1 = applicantCards.get(0);
+        assertThat(applicantCards).hasSize(1);
+        ApplicantCard applicantCard = applicantCards.get(0);
         assertAll(
-                () -> assertThat(applicantCard1.id()).isEqualTo(applicant1.getId()),
-                () -> assertThat(applicantCard1.name()).isEqualTo(applicant1.getName()),
-                () -> assertThat(applicantCard1.evaluationCount()).isEqualTo(2),
-                () -> assertThat(applicantCard1.averageScore()).isEqualTo(5.0)
-        );
-
-        ApplicantCard applicantCard2 = applicantCards.get(1);
-        assertAll(
-                () -> assertThat(applicantCard2.id()).isEqualTo(applicant2.getId()),
-                () -> assertThat(applicantCard2.name()).isEqualTo(applicant2.getName()),
-                () -> assertThat(applicantCard2.evaluationCount()).isEqualTo(1),
-                () -> assertThat(applicantCard2.averageScore()).isEqualTo(5.0)
+                () -> assertThat(applicantCard.id()).isEqualTo(applicant1.getId()),
+                () -> assertThat(applicantCard.name()).isEqualTo(applicant1.getName()),
+                () -> assertThat(applicantCard.evaluationCount()).isEqualTo(1),
+                () -> assertThat(applicantCard.averageScore()).isEqualTo(4.0)
         );
     }
 

--- a/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
+++ b/backend/src/test/java/com/cruru/applicant/service/ApplicantServiceTest.java
@@ -102,12 +102,12 @@ class ApplicantServiceTest extends ServiceTest {
         Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingRush(process1));
         applicantRepository.save(ApplicantFixture.pendingDobby(process2));
 
-        evaluationRepository.save(EvaluationFixture.fivePoints(process1, applicant1));
-        evaluationRepository.save(EvaluationFixture.fourPoints(process1, applicant2));
+        evaluationRepository.save(EvaluationFixture.fourPoints(process1, applicant1));
+        evaluationRepository.save(EvaluationFixture.fivePoints(process1, applicant2));
 
         String evaluationStatus = "EVALUATED";
-        String sortByCreatedAt = "DESC";
-        String sortByScore = null;
+        String sortByCreatedAt = null;
+        String sortByScore = "DESC";
 
         // when
         List<ApplicantCard> applicantCards = applicantService.findApplicantCards(

--- a/backend/src/test/java/com/cruru/process/facade/ProcessFacadeTest.java
+++ b/backend/src/test/java/com/cruru/process/facade/ProcessFacadeTest.java
@@ -77,7 +77,7 @@ class ProcessFacadeTest extends ServiceTest {
         Process process1 = processRepository.save(ProcessFixture.applyType(defaultDashboard));
         Process process2 = processRepository.save(ProcessFixture.interview(defaultDashboard));
         Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby(process1));
-        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingDobby(process2));
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingDobby(process1));
         List<Evaluation> evaluations1 = List.of(
                 EvaluationFixture.fivePoints(process1, applicant1),
                 EvaluationFixture.fourPoints(process1, applicant1),
@@ -87,14 +87,14 @@ class ProcessFacadeTest extends ServiceTest {
         evaluationRepository.saveAll(evaluations1);
 
         List<Evaluation> evaluations2 = List.of(
-                EvaluationFixture.fivePoints(process2, applicant2),
-                EvaluationFixture.fivePoints(process2, applicant2),
-                EvaluationFixture.fivePoints(process2, applicant2),
-                EvaluationFixture.fourPoints(process2, applicant2)
+                EvaluationFixture.fivePoints(process1, applicant2),
+                EvaluationFixture.fivePoints(process1, applicant2),
+                EvaluationFixture.fivePoints(process1, applicant2),
+                EvaluationFixture.fourPoints(process1, applicant2)
         );
         evaluationRepository.saveAll(evaluations2);
-        String sortByCreatedAt = "DESC";
-        String sortByScore = null;
+        String sortByCreatedAt = null;
+        String sortByScore = "DESC";
 
         // when
         ProcessResponses processResponses = processFacade.readAllByDashboardId(

--- a/backend/src/test/java/com/cruru/process/facade/ProcessFacadeTest.java
+++ b/backend/src/test/java/com/cruru/process/facade/ProcessFacadeTest.java
@@ -77,7 +77,7 @@ class ProcessFacadeTest extends ServiceTest {
         Process process1 = processRepository.save(ProcessFixture.applyType(defaultDashboard));
         Process process2 = processRepository.save(ProcessFixture.interview(defaultDashboard));
         Applicant applicant1 = applicantRepository.save(ApplicantFixture.pendingDobby(process1));
-        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingDobby(process1));
+        Applicant applicant2 = applicantRepository.save(ApplicantFixture.pendingDobby(process2));
         List<Evaluation> evaluations1 = List.of(
                 EvaluationFixture.fivePoints(process1, applicant1),
                 EvaluationFixture.fourPoints(process1, applicant1),
@@ -114,7 +114,7 @@ class ProcessFacadeTest extends ServiceTest {
                 () -> assertThat(processResponses.processResponses()).hasSize(2),
                 () -> assertThat(processId).isEqualTo(process1.getId()),
                 () -> assertThat(applicantCardResponse.id()).isEqualTo(applicant2.getId()),
-                () -> assertThat(applicantCardResponse.evaluationCount()).isEqualTo(evaluations1.size()),
+                () -> assertThat(applicantCardResponse.evaluationCount()).isEqualTo(evaluations2.size()),
                 () -> assertThat(applicantCardResponse.averageScore()).isEqualTo(4.75)
         );
     }


### PR DESCRIPTION
## 작업 내용
- applicantCard 조회 시 평가 점수와 갯수가 현재 소속된 프로세스에 대해서만 나오도록 수정

## 참고 사항
- 윈도우에서 실패하던 테스트도 수정했습니다.

## 관련 이슈
- closes #733
