### PR TITLE
fix: 공고수정시 수정하기 버튼 비활성화 버튼 수정

### DIFF
--- a/frontend/src/components/applyManagement/index.tsx
+++ b/frontend/src/components/applyManagement/index.tsx
@@ -36,9 +36,14 @@ export default function ApplyManagement() {
 
   const isNextBtnValid =
     applyState.length === DEFAULT_QUESTIONS.length ||
-    applyState
-      .slice(DEFAULT_QUESTIONS.length)
-      .every((question) => question.question.trim() && question.choices.length !== 1);
+    applyState.slice(DEFAULT_QUESTIONS.length).every((question) => {
+      const isQuestion = question.question.trim();
+      if (!(question.type === 'MULTIPLE_CHOICE' || question.type === 'SINGLE_CHOICE')) {
+        return isQuestion;
+      }
+      const isChoice = question.choices.some((choice) => choice.choice);
+      return isQuestion && isChoice;
+    });
 
   const handleSubmit = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();


### PR DESCRIPTION
## 작업 내용
- 공고수정시 수정하기 버튼 비활성화 버튼 수정

## 참고 사항
- KUCC 측에서 단일 Choice를 사용한 것으로 확인, 이에따라 valid 로직을 수정합니다.
