### PR TITLE
refactor(Email): 이메일 비동기 발송 요청에 Redis Queue 도입 (#1036)

### DIFF
--- a/backend/src/main/java/com/cruru/CruruApplication.java
+++ b/backend/src/main/java/com/cruru/CruruApplication.java
@@ -3,8 +3,10 @@ package com.cruru;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @ConfigurationPropertiesScan
 public class CruruApplication {
 

--- a/backend/src/main/java/com/cruru/advice/badrequest/TooManyRequestException.java
+++ b/backend/src/main/java/com/cruru/advice/badrequest/TooManyRequestException.java
@@ -1,0 +1,11 @@
+package com.cruru.advice.badrequest;
+
+import com.cruru.advice.CruruCustomException;
+import org.springframework.http.HttpStatus;
+
+public class TooManyRequestException extends CruruCustomException {
+
+    public TooManyRequestException(String message) {
+        super(message, HttpStatus.TOO_MANY_REQUESTS);
+    }
+}

--- a/backend/src/main/java/com/cruru/email/domain/Email.java
+++ b/backend/src/main/java/com/cruru/email/domain/Email.java
@@ -7,6 +7,8 @@ import com.cruru.email.exception.EmailContentLengthException;
 import com.cruru.email.exception.EmailSubjectLengthException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -46,17 +48,18 @@ public class Email extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "is_succeed")
-    private Boolean isSucceed;
+    @Column(name = "email_status")
+    @Enumerated(EnumType.STRING)
+    private EmailStatus status;
 
-    public Email(Club from, Applicant to, String subject, String content, Boolean isSucceed) {
+    public Email(Club from, Applicant to, String subject, String content, EmailStatus status) {
         validateSubjectLength(subject);
         validateContentLength(content);
         this.from = from;
         this.to = to;
         this.subject = subject;
         this.content = content;
-        this.isSucceed = isSucceed;
+        this.status = status;
     }
 
     private void validateSubjectLength(String subject) {
@@ -69,6 +72,10 @@ public class Email extends BaseEntity {
         if (content.length() > EMAIL_CONTENT_MAX_LENGTH) {
             throw new EmailContentLengthException(EMAIL_CONTENT_MAX_LENGTH, content.length());
         }
+    }
+
+    public void updateStatus(EmailStatus status) {
+        this.status = status;
     }
 
     @Override
@@ -96,7 +103,7 @@ public class Email extends BaseEntity {
                 ", to=" + to +
                 ", subject='" + subject + '\'' +
                 ", content='" + content + '\'' +
-                ", isSucceed=" + isSucceed +
+                ", isSucceed=" + status +
                 '}';
     }
 }

--- a/backend/src/main/java/com/cruru/email/domain/EmailStatus.java
+++ b/backend/src/main/java/com/cruru/email/domain/EmailStatus.java
@@ -1,0 +1,8 @@
+package com.cruru.email.domain;
+
+public enum EmailStatus {
+    PENDING,
+    DELIVERED,
+    FAILED
+    ;
+}

--- a/backend/src/main/java/com/cruru/email/dto/EmailQueueMessage.java
+++ b/backend/src/main/java/com/cruru/email/dto/EmailQueueMessage.java
@@ -1,0 +1,22 @@
+package com.cruru.email.dto;
+
+import java.io.Serializable;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class EmailQueueMessage implements Serializable {
+
+    private Long clubId;
+    private Long applicantId;
+    private String toEmail;
+    private String subject;
+    private String content;
+    private List<String> attachmentPaths;
+}

--- a/backend/src/main/java/com/cruru/email/exception/EmailRedisException.java
+++ b/backend/src/main/java/com/cruru/email/exception/EmailRedisException.java
@@ -1,0 +1,11 @@
+package com.cruru.email.exception;
+
+import com.cruru.advice.CruruCustomException;
+import org.springframework.http.HttpStatus;
+
+public class EmailRedisException extends CruruCustomException {
+
+    public EmailRedisException(String message) {
+        super(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend/src/main/java/com/cruru/email/exception/badrequest/EmailDuplicatedRequestException.java
+++ b/backend/src/main/java/com/cruru/email/exception/badrequest/EmailDuplicatedRequestException.java
@@ -1,0 +1,12 @@
+package com.cruru.email.exception.badrequest;
+
+import com.cruru.advice.badrequest.TooManyRequestException;
+
+public class EmailDuplicatedRequestException extends TooManyRequestException {
+
+    private static final String MESSAGE = ": 발송 대기 중인 이메일 요청과 중복됩니다.";
+
+    public EmailDuplicatedRequestException(String emailAddress) {
+        super(emailAddress + MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/cruru/email/facade/EmailFacade.java
+++ b/backend/src/main/java/com/cruru/email/facade/EmailFacade.java
@@ -10,9 +10,13 @@ import com.cruru.email.controller.request.VerifyCodeRequest;
 import com.cruru.email.controller.response.EmailHistoryResponse;
 import com.cruru.email.controller.response.EmailHistoryResponses;
 import com.cruru.email.domain.Email;
+import com.cruru.email.domain.EmailStatus;
+import com.cruru.email.dto.EmailQueueMessage;
 import com.cruru.email.exception.EmailAttachmentsException;
 import com.cruru.email.exception.EmailConflictException;
+import com.cruru.email.exception.badrequest.EmailDuplicatedRequestException;
 import com.cruru.email.service.EmailKeywordConverter;
+import com.cruru.email.service.EmailQueueService;
 import com.cruru.email.service.EmailRedisClient;
 import com.cruru.email.service.EmailService;
 import com.cruru.email.util.FileUtil;
@@ -36,26 +40,34 @@ public class EmailFacade {
     private final MemberService memberService;
     private final EmailRedisClient emailRedisClient;
     private final EmailKeywordConverter emailKeywordConverter;
+    private final EmailQueueService emailQueueService;
 
     public void send(EmailRequest request) {
         Club from = clubService.findById(request.clubId());
         List<Applicant> applicants = applicantService.findAllByIds(request.applicantIds());
-        sendAndSave(from, applicants, request.subject(), request.content(), request.files());
+        sendAndQueue(from, applicants, request.subject(), request.content(), request.files());
     }
 
-    private void sendAndSave(Club from, List<Applicant> tos, String subject, String text, List<MultipartFile> files) {
+    private void sendAndQueue(Club from, List<Applicant> tos, String subject, String text, List<MultipartFile> files) {
         List<File> tempFiles = saveTempFiles(from, subject, files);
+        List<String> attachmentPaths = tempFiles.stream().map(File::getAbsolutePath).toList();
 
-        List<CompletableFuture<Void>> futures = tos.stream()
-                .map(to -> {
-                    String content = emailKeywordConverter.convert(text, from, to);
-                    return emailService.send(from, to, subject, content, tempFiles);
-                })
-                .map(future -> future.thenAccept(emailService::save))
-                .toList();
 
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-                .thenRun(() -> FileUtil.deleteFiles(tempFiles));
+        tos.forEach(to -> {
+            // 이메일 내용에 대해 동적 키워드 변환을 미리 적용
+            String convertedContent = emailKeywordConverter.convert(text, from, to);
+            // EmailQueueMessage 생성
+            EmailQueueMessage message = new EmailQueueMessage(
+                    from.getId(),
+                    to.getId(),
+                    to.getEmail(),
+                    subject,
+                    convertedContent,
+                    attachmentPaths
+            );
+            // 큐에 등록 (이미 등록된 요청은 중복으로 등록되지 않음)
+            emailQueueService.enqueueEmail(message);
+        });
     }
 
     private List<File> saveTempFiles(Club from, String subject, List<MultipartFile> files) {
@@ -103,7 +115,7 @@ public class EmailFacade {
                 email.getSubject(),
                 email.getContent(),
                 email.getCreatedDate(),
-                email.getIsSucceed()
+                email.getStatus().equals(EmailStatus.DELIVERED)
         );
     }
 }

--- a/backend/src/main/java/com/cruru/email/service/EmailQueueService.java
+++ b/backend/src/main/java/com/cruru/email/service/EmailQueueService.java
@@ -1,0 +1,136 @@
+package com.cruru.email.service;
+
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.service.ApplicantService;
+import com.cruru.club.domain.Club;
+import com.cruru.club.service.ClubService;
+import com.cruru.email.dto.EmailQueueMessage;
+import com.cruru.email.exception.EmailRedisException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailQueueService {
+
+    private static final String EMAIL_REQUEST_KEY_PREFIX = "email_send:";
+    private static final String EMAIL_QUEUE_KEY = "email_queue";
+    private static final String EMAIL_PROCESSING_KEY = "email_queue_processing";
+    private static final long IDEMPOTENCY_TTL_MINUTES = 60;
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final EmailService emailService;
+    private final ClubService clubService;
+    private final ApplicantService applicantService;
+
+    public boolean enqueueEmail(EmailQueueMessage message) {
+        try {
+            String uniqueKey = generateUniqueKey(message.getToEmail(), message.getSubject(), message.getContent());
+            String redisUniqueKey = EMAIL_REQUEST_KEY_PREFIX + uniqueKey;
+
+            // 중복 여부 체크: setIfAbsent가 true이면 최초 등록, false면 중복
+            Boolean success = redisTemplate.opsForValue().setIfAbsent(
+                    redisUniqueKey,
+                    "1",
+                    IDEMPOTENCY_TTL_MINUTES,
+                    TimeUnit.MINUTES
+            );
+            if (success == null || !success) {
+                log.info("중복 이메일 발송 요청 감지: {}", redisUniqueKey);
+                return false;
+            }
+            // JSON으로 변환 후, Redis 리스트 큐에 적재
+            String messageJson = objectMapper.writeValueAsString(message);
+            redisTemplate.opsForList().rightPush(EMAIL_QUEUE_KEY, messageJson);
+            log.info("이메일 요청 큐에 등록: {}", messageJson);
+            return true;
+        } catch (Exception e) {
+            log.error("이메일 요청 등록 실패", e);
+            return false;
+        }
+    }
+
+    private String generateUniqueKey(String toEmail, String subject, String content) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            String combined = toEmail + subject + content;
+            byte[] digest = md.digest(combined.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : digest) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (Exception e) {
+            throw new EmailRedisException("Redis 고유 키 생성 중 오류");
+        }
+    }
+
+    @Scheduled(fixedDelay = 5000)
+    public void processQueue() {
+        try {
+            // 매 스케줄마다 처리 중인 메일 복구 시도
+            recoverStuckMessages();
+
+            String messageJson;
+            // leftPop 대신 rightPopAndLeftPush를 사용하여 원자적으로 처리 중 상태로 이동
+            while ((messageJson = redisTemplate.opsForList().rightPopAndLeftPush(EMAIL_QUEUE_KEY, EMAIL_PROCESSING_KEY))
+                    != null) {
+                log.info("큐에서 이메일 요청 처리 시작: {}", messageJson);
+                EmailQueueMessage message = objectMapper.readValue(messageJson, EmailQueueMessage.class);
+                Club from = clubService.findById(message.getClubId());
+                Applicant to = applicantService.findById(message.getApplicantId());
+                List<File> attachments = null;
+                if (message.getAttachmentPaths() != null) {
+                    attachments = message.getAttachmentPaths()
+                            .stream()
+                            .map(File::new)
+                            .toList();
+                }
+
+                // 이메일 전송: send()는 비동기로 처리 후 CompletableFuture<Email> 반환
+                String finalMessageJson = messageJson;
+                emailService.send(from, to, message.getSubject(), message.getContent(), attachments)
+                        .thenAccept(email -> {
+                            // 성공적으로 처리되면 처리 중 리스트에서 제거
+                            redisTemplate.opsForList().remove(EMAIL_PROCESSING_KEY, 1, finalMessageJson);
+                            emailService.save(email);
+                            log.info("이메일 전송 완료 및 처리 대기열에서 제거");
+                        }).exceptionally(ex -> {
+                            log.error("이메일 전송 중 오류 발생: {}", ex.getMessage());
+                            // 오류 발생 시 처리 중 리스트에서 제거 후 다시 메인 큐로 이동
+                            redisTemplate.opsForList().remove(EMAIL_PROCESSING_KEY, 1, finalMessageJson);
+                            redisTemplate.opsForList().rightPush(EMAIL_QUEUE_KEY, finalMessageJson);
+                            log.info("전송 실패한 메일을 재처리 큐에 등록");
+                            return null;
+                        });
+            }
+        } catch (Exception e) {
+            log.error("이메일 Redis 큐 처리 중 예외 발생", e);
+        }
+    }
+
+    private void recoverStuckMessages() {
+        int count = 0;
+        while (redisTemplate.opsForList().rightPopAndLeftPush(EMAIL_PROCESSING_KEY, EMAIL_QUEUE_KEY) != null) {
+            count++;
+        }
+        if (count > 0) {
+            log.info("애플리케이션 시작 시 처리되지 않은 메일 {}건 복원 완료", count);
+        }
+    }
+}

--- a/backend/src/main/resources/db/migration/V2_5__update_email_status.sql
+++ b/backend/src/main/resources/db/migration/V2_5__update_email_status.sql
@@ -1,0 +1,10 @@
+ALTER TABLE email CHANGE COLUMN is_succeed email_status VARCHAR(20) NOT NULL;
+
+UPDATE email
+SET email_status = CASE
+                       WHEN email_status = '1' THEN 'DELIVERED'
+                       WHEN email_status = '0' THEN 'FAILED'
+                       ELSE 'PENDING'
+    END;
+
+ALTER TABLE email MODIFY COLUMN email_status VARCHAR(20) NOT NULL DEFAULT 'PENDING';

--- a/backend/src/test/java/com/cruru/email/controller/EmailControllerTest.java
+++ b/backend/src/test/java/com/cruru/email/controller/EmailControllerTest.java
@@ -338,7 +338,7 @@ class EmailControllerTest extends ControllerTest {
                                         fieldWithPath("subject").description("이메일 제목"),
                                         fieldWithPath("content").description("이메일 본문"),
                                         fieldWithPath("createdDate").description("전송 날짜"),
-                                        fieldWithPath("isSucceed").description("전송 성공 여부")
+                                        fieldWithPath("isSucceed").description("이메일 상태 (true, false)")
                                 )
                 ))
                 .when().get("/v1/emails/{clubId}/{applicantId}", defaultClub.getId(), applicant.getId())

--- a/backend/src/test/java/com/cruru/email/domain/EmailTest.java
+++ b/backend/src/test/java/com/cruru/email/domain/EmailTest.java
@@ -26,7 +26,7 @@ class EmailTest {
         String content = EmailFixture.APPROVE_CONTENT;
 
         // when&then
-        assertThatThrownBy(() -> new Email(null, null, invalidSubject, content, true))
+        assertThatThrownBy(() -> new Email(null, null, invalidSubject, content, EmailStatus.DELIVERED))
                 .isInstanceOf(EmailSubjectLengthException.class);
     }
 
@@ -44,7 +44,7 @@ class EmailTest {
         String invalidContent = stringBuilder.append("!").toString();
 
         // when&then
-        assertThatThrownBy(() -> new Email(null, null, subject, invalidContent, true))
+        assertThatThrownBy(() -> new Email(null, null, subject, invalidContent, EmailStatus.DELIVERED))
                 .isInstanceOf(EmailContentLengthException.class);
     }
 }

--- a/backend/src/test/java/com/cruru/email/domain/repository/EmailRepositoryTest.java
+++ b/backend/src/test/java/com/cruru/email/domain/repository/EmailRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.cruru.applicant.domain.Applicant;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.email.domain.Email;
+import com.cruru.email.domain.EmailStatus;
 import com.cruru.util.RepositoryTest;
 import com.cruru.util.fixture.ApplicantFixture;
 import com.cruru.util.fixture.EmailFixture;
@@ -42,7 +43,7 @@ class EmailRepositoryTest extends RepositoryTest {
                 null,
                 EmailFixture.SUBJECT,
                 EmailFixture.REJECT_CONTENT,
-                true
+                EmailStatus.DELIVERED
         );
         emailRepository.save(updatedEmail);
 

--- a/backend/src/test/java/com/cruru/email/facade/EmailFacadeTest.java
+++ b/backend/src/test/java/com/cruru/email/facade/EmailFacadeTest.java
@@ -2,14 +2,15 @@ package com.cruru.email.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.cruru.applicant.domain.Applicant;
+import com.cruru.club.domain.Club;
 import com.cruru.applicant.domain.repository.ApplicantRepository;
 import com.cruru.applyform.domain.repository.ApplyFormRepository;
 import com.cruru.email.controller.request.EmailRequest;
@@ -19,30 +20,30 @@ import com.cruru.email.controller.response.EmailHistoryResponse;
 import com.cruru.email.controller.response.EmailHistoryResponses;
 import com.cruru.email.domain.Email;
 import com.cruru.email.domain.repository.EmailRepository;
+import com.cruru.email.dto.EmailQueueMessage;
 import com.cruru.email.exception.EmailConflictException;
 import com.cruru.email.exception.badrequest.VerificationCodeMismatchException;
 import com.cruru.email.exception.badrequest.VerificationCodeNotFoundException;
+import com.cruru.email.service.EmailKeywordConverter;
+import com.cruru.email.service.EmailQueueService;
 import com.cruru.email.service.EmailRedisClient;
 import com.cruru.email.service.EmailService;
 import com.cruru.member.domain.repository.MemberRepository;
-import com.cruru.process.domain.Process;
 import com.cruru.process.domain.repository.ProcessRepository;
 import com.cruru.util.ServiceTest;
 import com.cruru.util.fixture.ApplicantFixture;
-import com.cruru.util.fixture.ApplyFormFixture;
 import com.cruru.util.fixture.EmailFixture;
 import com.cruru.util.fixture.MemberFixture;
-import com.cruru.util.fixture.ProcessFixture;
-import jakarta.mail.internet.MimeMessage;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @DisplayName("발송 내역 파사드 테스트")
 class EmailFacadeTest extends ServiceTest {
 
@@ -68,38 +69,13 @@ class EmailFacadeTest extends ServiceTest {
     private EmailFacade emailFacade;
 
     @MockBean
+    private EmailQueueService emailQueueService;
+
+    @MockBean
     private EmailRedisClient emailRedisClient;
 
-    @DisplayName("이메일을 비동기로 발송하고, 발송 내역을 저장한다.")
-    @Test
-    void sendAndSave() {
-        // given
-        Mockito.doAnswer(invocation -> {
-            TimeUnit.SECONDS.sleep(1);
-            return null;
-        }).when(javaMailSender).send(any(MimeMessage.class));
-
-        applyFormRepository.save(ApplyFormFixture.backend(defaultDashboard));
-        Process process = processRepository.save(ProcessFixture.applyType(defaultDashboard));
-        Applicant applicant = applicantRepository.save(ApplicantFixture.pendingDobby(process));
-        EmailRequest request = new EmailRequest(
-                defaultClub.getId(),
-                List.of(applicant.getId()),
-                EmailFixture.SUBJECT,
-                EmailFixture.APPROVE_CONTENT,
-                null
-        );
-
-        // when
-        emailFacade.send(request);
-
-        // then
-        verify(javaMailSender, times(0)).send(any(MimeMessage.class));
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
-            verify(javaMailSender, times(1)).send(any(MimeMessage.class));
-            verify(emailService, times(1)).save(any(Email.class));
-        });
-    }
+    @MockBean
+    private EmailKeywordConverter emailKeywordConverter;
 
     @DisplayName("이미 가입된 이메일로 인증을 시도하면 예외가 발생한다.")
     @Test
@@ -110,8 +86,7 @@ class EmailFacadeTest extends ServiceTest {
         SendVerificationCodeRequest request = new SendVerificationCodeRequest(email);
 
         // when&then
-        assertThatThrownBy(() -> emailFacade.sendVerificationCode(request))
-                .isInstanceOf(EmailConflictException.class);
+        assertThatThrownBy(() -> emailFacade.sendVerificationCode(request)).isInstanceOf(EmailConflictException.class);
     }
 
     @DisplayName("이메일 인증 성공 시, 인증 코드가 검증된다.")
@@ -142,8 +117,7 @@ class EmailFacadeTest extends ServiceTest {
         when(emailRedisClient.getVerificationCode(email)).thenReturn(null);
 
         // when&then
-        assertThatThrownBy(() -> emailFacade.verifyCode(request))
-                .isInstanceOf(VerificationCodeNotFoundException.class)
+        assertThatThrownBy(() -> emailFacade.verifyCode(request)).isInstanceOf(VerificationCodeNotFoundException.class)
                 .hasMessage("인증 코드가 존재하지 않거나 만료되었습니다.");
     }
 
@@ -159,8 +133,7 @@ class EmailFacadeTest extends ServiceTest {
         when(emailRedisClient.getVerificationCode(email)).thenReturn(correctCode);
 
         // when&then
-        assertThatThrownBy(() -> emailFacade.verifyCode(request))
-                .isInstanceOf(VerificationCodeMismatchException.class)
+        assertThatThrownBy(() -> emailFacade.verifyCode(request)).isInstanceOf(VerificationCodeMismatchException.class)
                 .hasMessage("인증 코드가 일치하지 않습니다.");
     }
 
@@ -180,7 +153,42 @@ class EmailFacadeTest extends ServiceTest {
         assertAll(
                 () -> assertThat(emailHistoryResponse.subject()).isEqualTo(email.getSubject()),
                 () -> assertThat(emailHistoryResponse.content()).isEqualTo(email.getContent()),
-                () -> assertThat(emailHistoryResponse.isSucceed()).isEqualTo(email.getIsSucceed())
+                () -> assertThat(emailHistoryResponse.isSucceed()).isTrue()
         );
+    }
+
+    @DisplayName("이메일 발송 요청이 Redis 큐에 정상 등록된다.")
+    @Test
+    void send_enqueueEmails() {
+        // given
+        // 임시 파일을 위한 MockMultipartFile 생성
+        var file = new MockMultipartFile("file", "test.txt", "text/plain", "Test data".getBytes());
+
+        // 테스트용 Applicant 생성
+        Applicant applicant = ApplicantFixture.pendingDobby();
+        applicant = applicantRepository.save(applicant);
+
+        // EmailRequest 생성
+        var request = new EmailRequest(
+                defaultClub.getId(),
+                List.of(applicant.getId()),
+                "Test Subject",
+                "Test Content",
+                List.of(file)
+        );
+
+        // EmailKeywordConverter가 원본 내용을 그대로 반환하도록 설정
+        when(emailKeywordConverter.convert(anyString(), any(Club.class), any(Applicant.class)))
+                .thenReturn("Test Content");
+
+        // 이메일 큐 등록 메서드가 항상 true를 반환한다고 가정
+        when(emailQueueService.enqueueEmail(any(EmailQueueMessage.class))).thenReturn(true);
+
+        // when
+        emailFacade.send(request);
+
+        // then
+        // 수신자 수 만큼 (여기서는 1명) EmailQueueService.enqueueEmail이 호출되어야 함
+        verify(emailQueueService, times(1)).enqueueEmail(any(EmailQueueMessage.class));
     }
 }

--- a/backend/src/test/java/com/cruru/email/service/EmailQueueServiceTest.java
+++ b/backend/src/test/java/com/cruru/email/service/EmailQueueServiceTest.java
@@ -1,0 +1,228 @@
+package com.cruru.email.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cruru.applicant.domain.Applicant;
+import com.cruru.applicant.service.ApplicantService;
+import com.cruru.club.domain.Club;
+import com.cruru.club.service.ClubService;
+import com.cruru.email.domain.Email;
+import com.cruru.email.domain.EmailStatus;
+import com.cruru.email.dto.EmailQueueMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@DisplayName("EmailQueueService 단위 테스트")
+class EmailQueueServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private ListOperations<String, String> listOperations;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private ClubService clubService;
+
+    @Mock
+    private ApplicantService applicantService;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private EmailQueueService emailQueueService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(redisTemplate.opsForList()).thenReturn(listOperations);
+        emailQueueService = new EmailQueueService(
+                redisTemplate,
+                objectMapper,
+                emailService,
+                clubService,
+                applicantService
+        );
+    }
+
+    @Test
+    @DisplayName("중복이 아닌 이메일 요청은 큐에 정상 등록된다.")
+    void enqueueEmail_success() {
+        // given
+        EmailQueueMessage message = new EmailQueueMessage(
+                1L,
+                2L,
+                "test@example.com",
+                "Test Subject",
+                "Test Content",
+                List.of("/tmp/file1.txt")
+        );
+        when(valueOperations.setIfAbsent(anyString(), eq("1"), eq(60L), eq(TimeUnit.MINUTES))).thenReturn(Boolean.TRUE);
+
+        // when
+        boolean result = emailQueueService.enqueueEmail(message);
+
+        // then
+        assertThat(result).isTrue();
+        verify(listOperations, times(1)).rightPush(eq("email_queue"), anyString());
+    }
+
+    @Test
+    @DisplayName("중복된 이메일 요청은 큐에 등록되지 않는다.")
+    void enqueueEmail_duplicate() {
+        // given
+        EmailQueueMessage message = new EmailQueueMessage(
+                1L,
+                2L,
+                "duplicate@example.com",
+                "Subject",
+                "Content",
+                List.of("/tmp/file1.txt")
+        );
+        when(valueOperations.setIfAbsent(
+                anyString(),
+                eq("1"),
+                eq(60L),
+                eq(TimeUnit.MINUTES)
+        )).thenReturn(Boolean.FALSE);
+
+        // when
+        boolean result = emailQueueService.enqueueEmail(message);
+
+        // then
+        assertThat(result).isFalse();
+        verify(listOperations, never()).rightPush(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("큐에 저장된 이메일 요청을 꺼내어 처리한다.")
+    void processQueue_processOneMessage() throws Exception {
+        // given
+        EmailQueueMessage message = new EmailQueueMessage(
+                1L,
+                2L,
+                "process@example.com",
+                "Subject",
+                "Content",
+                List.of("/tmp/file1.txt")
+        );
+        String messageJson = objectMapper.writeValueAsString(message);
+        
+        // rightPopAndLeftPush를 사용하여 원자적으로 처리 중 상태로 이동하는 것을 모킹
+        when(listOperations.rightPopAndLeftPush("email_queue", "email_queue_processing"))
+            .thenReturn(messageJson, null);
+
+        Club dummyClub = mock(Club.class);
+        Applicant dummyApplicant = mock(Applicant.class);
+        when(clubService.findById(1L)).thenReturn(dummyClub);
+        when(applicantService.findById(2L)).thenReturn(dummyApplicant);
+
+        // emailService.send가 완료된 이메일 객체를 반환하도록 시뮬레이션
+        Email dummyEmail = new Email(dummyClub, dummyApplicant, "Subject", "Content", EmailStatus.DELIVERED);
+        CompletableFuture<Email> emailFuture = CompletableFuture.completedFuture(dummyEmail);
+        when(emailService.send(
+                eq(dummyClub),
+                eq(dummyApplicant),
+                eq("Subject"),
+                eq("Content"),
+                any(List.class)
+        )).thenReturn(emailFuture);
+
+        // when
+        emailQueueService.processQueue();
+        
+        // CompletableFuture가 완료될 때까지 대기
+        emailFuture.join();
+        
+        // then
+        verify(emailService, times(1)).send(
+                eq(dummyClub),
+                eq(dummyApplicant),
+                eq("Subject"),
+                eq("Content"),
+                any(List.class)
+        );
+        verify(emailService, times(1)).save(any(Email.class));
+        
+        // 처리 중 큐에서 메시지가 제거되었는지 확인
+        verify(listOperations, times(1)).remove("email_queue_processing", 1, messageJson);
+    }
+
+    @Test
+    @DisplayName("큐가 비어있으면 아무런 처리도 하지 않는다.")
+    void processQueue_emptyQueue() {
+        // rightPopAndLeftPush가 바로 null을 반환하도록 설정
+        when(listOperations.rightPopAndLeftPush("email_queue", "email_queue_processing")).thenReturn(null);
+        // when
+        emailQueueService.processQueue();
+        // then: 이메일 전송 관련 메서드가 호출되지 않음
+        verify(emailService, never()).send(any(), any(), anyString(), anyString(), any(List.class));
+    }
+
+    @Test
+    @DisplayName("큐 처리 중 예외가 발생해도 정상적으로 처리된다.")
+    void processQueue_handleException() throws Exception {
+        // given
+        EmailQueueMessage message = new EmailQueueMessage(
+                1L,
+                2L,
+                "process@example.com",
+                "Subject",
+                "Content",
+                List.of("/tmp/file1.txt")
+        );
+        String messageJson = objectMapper.writeValueAsString(message);
+        when(listOperations.rightPopAndLeftPush("email_queue", "email_queue_processing")).thenReturn(messageJson);
+
+        // 예외 발생 시뮬레이션
+        when(clubService.findById(any())).thenThrow(new RuntimeException("테스트 예외"));
+
+        // when
+        emailQueueService.processQueue();
+
+        // then
+        // 예외가 발생해도 메서드가 정상적으로 종료되어야 함
+        verify(clubService, times(1)).findById(1L);
+        verify(emailService, never()).send(any(), any(), anyString(), anyString(), any(List.class));
+    }
+
+    @Test
+    @DisplayName("JSON 파싱 오류가 발생해도 정상적으로 처리된다.")
+    void processQueue_handleJsonParseException() {
+        // given
+        // 잘못된 JSON 형식의 메시지
+        String invalidJson = "{invalid_json}";
+        when(listOperations.rightPopAndLeftPush("email_queue", "email_queue_processing")).thenReturn(invalidJson, null);
+
+        // when
+        emailQueueService.processQueue();
+
+        // then
+        // 예외가 발생해도 메서드가 정상적으로 종료되어야 함
+        verify(emailService, never()).send(any(), any(), anyString(), anyString(), any(List.class));
+    }
+}

--- a/backend/src/test/java/com/cruru/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/cruru/member/acceptance/MemberAcceptanceTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-public class MemberAcceptanceTest extends AcceptanceTest {
+@DisplayName("멤버 생성/변경 권한 테스트")
+class MemberAcceptanceTest extends AcceptanceTest {
 
     @MockBean
     private EmailRedisClient emailRedisClient;

--- a/backend/src/test/java/com/cruru/util/fixture/EmailFixture.java
+++ b/backend/src/test/java/com/cruru/util/fixture/EmailFixture.java
@@ -4,6 +4,7 @@ import com.cruru.applicant.domain.Applicant;
 import com.cruru.club.domain.Club;
 import com.cruru.dashboard.domain.Dashboard;
 import com.cruru.email.domain.Email;
+import com.cruru.email.domain.EmailStatus;
 
 public class EmailFixture {
 
@@ -21,7 +22,7 @@ public class EmailFixture {
                 null,
                 SUBJECT,
                 APPROVE_CONTENT,
-                true
+                EmailStatus.DELIVERED
         );
     }
 
@@ -31,7 +32,7 @@ public class EmailFixture {
                 null,
                 SUBJECT,
                 REJECT_CONTENT,
-                true
+                EmailStatus.DELIVERED
         );
     }
 
@@ -41,7 +42,7 @@ public class EmailFixture {
                 to,
                 SUBJECT,
                 REJECT_CONTENT,
-                true
+                EmailStatus.DELIVERED
         );
     }
 }


### PR DESCRIPTION
refactor(Email): 이메일 비동기 발송 요청에 Redis Queue 도입 (#1036)

* feat(EmailStatus): 이메일 전송 상태 Enum 추가

* feat(Email): 이메일 도메인 필드 isSucceed 제거 및 EmailStatus 추가

* feat: Email 테이블 스키마 변경 적용을 위한 Flyway 스크립트 작성

* feat(Email): Redis 기반 이메일 큐 서비스 구현

* feat(Email): 이메일 중복 요청 예외 처리 구현

* feat(Email): 이메일 발송 시스템에 Redis 큐 적용

* refactor: 멤버 테스트 코드 스타일 개선

* feat(EmailQueueService): Redis Queue에 메일 발송 처리 중 상태 추가 및 테스트 생성

* fix: 불필요 수정사항 롤백

* refactor: Email Status(발송 결과 상태값) API 응답 프론트 작업에 맞춰 변경 롤백

* fix-be: 스케줄러를 이용한 워커 활성화 및 DTO 수정

* fix-be: flyway v2.4 version 충돌 파일명 수정

## 작업 내용
- 

## 참고 사항
-

## 관련 이슈
- 


## PR 체크리스트
- [x] 테스트는 모두 통과했나요?
- [x] 빌드는 성공했나요?
- [x] 코드 포맷팅을 진행했나요?
- [x] PR 내부의 예시는 삭제하셨나요?
